### PR TITLE
chore(ci): update Actions (upload-artifact v4, setup-python v5, codecov v4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -48,9 +48,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -113,7 +113,7 @@ jobs:
         run: uv run safety check --save-json safety-report.json
 
       - name: Upload security reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: security-reports
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -147,7 +147,7 @@ jobs:
         run: uv run mkdocs build
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: site/


### PR DESCRIPTION
This PR updates the CI workflow to use current, supported GitHub Actions and fixes the failing jobs due to the artifact action deprecation.

Changes:
- actions/upload-artifact: v3 -> v4 (resolves deprecation error)
- actions/setup-python: v4 -> v5 (all jobs)
- codecov/codecov-action: v3 -> v4 (updated input `file` -> `files`)

Why:
- GitHub deprecated `actions/upload-artifact@v3` causing failures in the Docs and Security jobs.
- Keeping actions up-to-date improves reliability and security.

Notes:
- No other workflow logic was changed.
- After merge, the CI should pass the artifact step, and Codecov uploads via v4.

Ref:
- Deprecation notice: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
