### PR TITLE
fix(deps): clear remaining open security alerts (starlette, idna)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -880,11 +880,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2377,15 +2377,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves the **2 remaining open Dependabot security alerts**. The earlier comprehensive security review (#35) already patched 40 of the repo's 42 historical advisories; these two transitive dependencies were the only ones still open:

| Package | Was | Now | Advisory |
|---------|-----|-----|----------|
| starlette | 0.50.0 | **1.2.1** | Missing Host header validation poisons `request.url.path`, bypassing path-based security checks (alert #42) |
| idna | 3.11 | **3.18** | Crafted input to `idna.encode()` can bypass the CVE-2024-3651 fix (alert #38) |

Both are transitive deps (starlette via `mcp`, idna via `anyio`/`httpx`/etc.), so this is a **lockfile-only** change produced with `uv lock --upgrade-package starlette --upgrade-package idna`.

## Why a combined PR instead of the Dependabot PRs

The open Dependabot PRs (#27–34) were all based on a pre-#35 `main` and had red CI (their lock still pinned the vulnerable `filelock 3.20.0`). Six of them are already obsolete — `main` now has those versions or newer (one, #34, would even *downgrade* python-multipart). Only the starlette and idna bumps carried changes `main` still needs, so they're consolidated here against current `main`. The stale Dependabot PRs will be closed.

## Verification (local, current main + this change)

- `uv run pytest` — **525 passed**, coverage 91.7% (gate 85%)
- `uv run ruff check .` / `ruff format --check` — clean
- `uv run mypy src` — no issues
- `uv run bandit -r src/` — clean
- `uv run safety check` — **0 vulnerabilities** (previously failed on filelock)

starlette is a major bump (0.x → 1.x); the full suite passes, so the `mcp` HTTP/SSE transport remains compatible.

Closes the open advisories for `starlette` and `idna`.