### PR TITLE
chore: prepare release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TBD
 
+## [0.3.0] - 2026-06-07
+
+### Security
+
+- Pin the SSRF-validated IP address for the actual connection so a hostname can
+  no longer be re-resolved to an internal or rebinding address between the
+  validation check and the connect (Gopher and Gemini).
+- Add a denylist of dangerous service ports (SSH, SMTP, Redis, etc.) as
+  defense-in-depth.
+- Close the socket on every TLS connection/handshake failure (previously leaked
+  file descriptors under repeated failures).
+- Normalize TOFU trust-store host keys so a casing/trailing-dot variant cannot
+  establish a second pin, and reject a non-valid TOFU result (fail closed).
+- Fail closed on a corrupt client-certificate registry, and write the trust
+  store, certificate registry, and private keys owner-only.
+- Scan dependencies with `pip-audit` in CI (replacing the deprecated
+  `safety check`) and pin the PyPI publish action to a commit SHA.
+
+### Added
+
+- Range constraints on model port/size fields and scheme-based classification of
+  gemtext links (relative links are internal, not external).
+
+### Changed
+
+- Fetch tools now return structured error results instead of raising, so invalid
+  input, batch limits, and client-setup failures no longer surface as raw tool
+  errors.
+- Server settings are read under the `GOPHER_MCP_` environment prefix (e.g.
+  `GOPHER_MCP_LOG_LEVEL`) so common ambient variables no longer leak into
+  configuration. **Update any `LOG_LEVEL`/`DEVELOPMENT_MODE`/`LOG_FILE_PATH`
+  env vars to the prefixed names.**
+- `--mount-path` is now rejected for transports that ignore it (was silently
+  dropped for stdio/streamable-http).
+- Per-request URL/query logging moved to DEBUG.
+- Client connections are released on shutdown.
+
+### Fixed
+
+- Reject explicit invalid or zero ports in Gopher/Gemini URLs instead of
+  silently coercing them to the default.
+- Percent-decode Gopher selectors to their on-wire form.
+- Parse gemtext on CRLF/LF only and preserve preformatted lines verbatim.
+- Stop double-wrapping the Gemini response parser's own validation errors.
+- Enforce the project's full ruff ruleset (it was silently shadowed by a stray
+  config file) and clear a transitive `jaraco-context` advisory.
+
 ## [0.2.2] - 2025-01-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gopher-mcp"
-version = "0.2.2"
+version = "0.3.0"
 description = "A cross-platform Model Context Protocol (MCP) server for browsing Gopher resources"
 readme = "README.md"
 license = "MIT"

--- a/src/gopher_mcp/__init__.py
+++ b/src/gopher_mcp/__init__.py
@@ -4,7 +4,7 @@ This package provides a cross-platform MCP server that allows LLMs to browse
 Gopher and Gemini resources safely and efficiently.
 """
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 __author__ = "Gopher MCP Team"
 __email__ = "team@gopher-mcp.dev"
 __license__ = "MIT"


### PR DESCRIPTION
Prepares the 0.3.0 release on top of #37.

- Bumps the version to `0.3.0` in `pyproject.toml` and `src/gopher_mcp/__init__.py` (the release script only touches pyproject, so `__init__` is updated by hand to stay in sync).
- Adds a `## [0.3.0]` section to `CHANGELOG.md` documenting the security, behavior, and fix changes from #37, with the user-visible ones called out (the `GOPHER_MCP_` env prefix and the structured tool-error responses).

Minor version bump because of those user-visible behavior changes.

### After merge — to publish
Tag the merge commit and push the tag; the release workflow publishes to PyPI via trusted publishing:

    git tag -a v0.3.0 -m "Release 0.3.0" && git push origin v0.3.0

(Or run `scripts/prepare-release.py` if you prefer its tag flow.)

No code changes — just version + changelog. Full suite green (554 passed), ruff/format/mypy clean.