### PR TITLE
Follow-up hardening: trust-store durability, request deadlines, batch contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disabling TOFU now logs a prominent warning (it leaves Gemini connections
   unauthenticated under CERT_NONE TLS); a certificate already expired on first
   use is pinned but flagged; and a status-11 input answer is no longer logged.
+- Bound DNS resolution by the request deadline in both clients, so a hostname
+  pointing at a tarpit nameserver can no longer stall a worker (or tie up an
+  event-loop executor thread) far past `timeout_seconds`.
+- TOFU trust store hardening: certificate fingerprints are canonicalized (a pin
+  pasted in the `openssl`/browser colon-uppercase form now matches the wire
+  digest); cross-process writes take an advisory lock and merge with the on-disk
+  store so two server instances can't silently drop each other's pins; and the
+  store write is `fsync`'d for crash durability.
+- Optional `GEMINI_TOFU_REJECT_EXPIRED` fails closed on a certificate outside
+  its validity window (`notBefore` is enforced on first use), reported with a
+  distinct `CERTIFICATE_EXPIRED` code rather than a misleading "certificate
+  changed".
+- Gopher URL parsing fails closed on percent-decoded control characters in the
+  selector/search at parse time, not only via the client's re-check.
+- Defensive fetch-error paths return a generic message to the model instead of
+  echoing the raw internal exception string (full detail is still logged).
 
 ### Added
 
@@ -26,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   off) that also honours a Gemini status-44 SLOW_DOWN backoff.
 - Opt-in Gemini MIME content filter (`GEMINI_DENIED_MIME_TYPES`, supports
   `type/*` wildcards).
+- `GEMINI_TOFU_REJECT_EXPIRED` (default off) to fail closed on a Gemini
+  certificate outside its validity window.
 - LLM-facing text render cap (`GOPHER_/GEMINI_MAX_RENDERED_CHARS`, default 50000)
   with a `truncated` flag, distinct from the network byte cap.
 - Rich tool input schemas (descriptions + examples), `readOnlyHint`/
@@ -40,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   certificate results carry the 60/61/62 subcode (61/62 are rejections, not
   prompts); relative Gemini redirects are resolved to absolute URLs.
 - `__version__` is single-sourced from the package metadata.
+- The batch fetch tools return one error per input URL on an over-limit or
+  client-setup failure, keeping responses index-aligned with the request list.
+- The per-host rate limiter sweeps hosts whose reservation has elapsed, so a
+  long-lived server no longer accumulates state for every distinct host visited.
+- Collapsed the duplicate client-manager singleton so `cleanup()` fully resets
+  it and the next call builds a fresh manager.
 
 ### Fixed
 

--- a/src/gopher_mcp/config.py
+++ b/src/gopher_mcp/config.py
@@ -146,6 +146,13 @@ class GeminiConfig(BaseSettings):
         default=None,
         description="TOFU storage file path",
     )
+    tofu_reject_expired: bool = Field(
+        default=False,
+        description="Fail closed on a certificate outside its validity window "
+        "(already expired, or not yet valid on first use) instead of accepting "
+        "it with a warning. Off by default to match the conventional Gemini TOFU "
+        "model where the fingerprint pin is the real authenticator.",
+    )
     client_certs_enabled: bool = Field(
         default=True,
         description="Enable client certificate support",

--- a/src/gopher_mcp/gemini_client.py
+++ b/src/gopher_mcp/gemini_client.py
@@ -19,7 +19,7 @@ from .models import (
 )
 from .ratelimit import RateLimiter
 from .ssrf import SSRFError, normalize_host, validate_target
-from .tofu import TOFUManager, TOFUValidationError
+from .tofu import TOFUExpiredError, TOFUManager, TOFUValidationError
 from .utils import (
     parse_gemini_response,
     parse_gemini_url,
@@ -52,6 +52,7 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         tls_config: TLSConfig | None = None,
         tofu_enabled: bool = True,
         tofu_storage_path: str | None = None,
+        tofu_reject_expired: bool = False,
         client_certs_enabled: bool = True,
         client_certs_storage_path: str | None = None,
         max_rendered_chars: int = DEFAULT_MAX_RENDERED_CHARS,
@@ -70,6 +71,8 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
             tls_config: TLS configuration (uses defaults if None)
             tofu_enabled: Whether to enable TOFU certificate validation
             tofu_storage_path: Path to TOFU storage file
+            tofu_reject_expired: Fail closed on a certificate outside its
+                validity window instead of accepting it with a warning
             client_certs_enabled: Whether to enable client certificate management
             client_certs_storage_path: Path to client certificate storage directory
         """
@@ -94,7 +97,9 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         # Initialize TOFU manager
         self.tofu_manager: TOFUManager | None = None
         if self.tofu_enabled:
-            self.tofu_manager = TOFUManager(tofu_storage_path)
+            self.tofu_manager = TOFUManager(
+                tofu_storage_path, reject_expired=tofu_reject_expired
+            )
         else:
             # Gemini TLS runs with CERT_NONE, so TOFU is the ONLY peer
             # authentication. Disabling it leaves every connection unauthenticated
@@ -222,6 +227,12 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         except SSRFError as e:
             # Policy messages name a host/category only (no internal detail).
             return self._error_result(url, "BLOCKED", str(e), e)
+        except TOFUExpiredError as e:
+            # Distinct from a fingerprint change: the cert MATCHES the pin but is
+            # outside its validity window. Report it accurately (must precede the
+            # TOFUValidationError handler since it is a subclass). The message
+            # names host:port and a category only -- safe to surface.
+            return self._error_result(url, "CERTIFICATE_EXPIRED", str(e), e)
         except TOFUValidationError as e:
             return self._error_result(
                 url,
@@ -232,6 +243,9 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
             )
         except TLSConnectionError as e:
             return self._error_result(url, "TLS_ERROR", "TLS connection failed", e)
+        except TimeoutError as e:
+            # DNS resolution, connect, or read exceeded the request deadline.
+            return self._error_result(url, "FETCH_ERROR", "The request timed out", e)
         except ValueError as e:
             # URL/host validation errors are safe to surface verbatim.
             return self._error_result(url, "INVALID_REQUEST", str(e), e)
@@ -288,10 +302,17 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
             # SSRF guard: reject internal/loopback/link-local targets before
             # opening the TLS connection, and pin the connection to a validated
             # IP so the TLS layer can't re-resolve to a rebinding answer.
-            connect_addresses = await validate_target(
-                parsed_url.host,
-                parsed_url.port,
-                allow_local=self.allow_local_hosts,
+            #
+            # Bound DNS resolution by the request deadline: getaddrinfo is
+            # otherwise unbounded (a tarpit nameserver could stall a worker -- and
+            # tie up an event-loop executor thread -- far past timeout_seconds).
+            connect_addresses = await asyncio.wait_for(
+                validate_target(
+                    parsed_url.host,
+                    parsed_url.port,
+                    allow_local=self.allow_local_hosts,
+                ),
+                timeout=self.timeout_seconds,
             )
             # Prefer an IPv4 address (the historical behavior was AF_INET-only),
             # but fall back to the first address so IPv6-only hosts still work.

--- a/src/gopher_mcp/gopher_client.py
+++ b/src/gopher_mcp/gopher_client.py
@@ -1,5 +1,6 @@
 """Gopher protocol client implementation."""
 
+import asyncio
 import re
 import time
 from collections import OrderedDict
@@ -296,11 +297,24 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
         # SSRF guard: reject internal/loopback/link-local targets before
         # connecting, and pin the connection to the exact IPs we validated so
         # the transport can't re-resolve to a rebinding answer.
-        connect_addresses = await validate_target(
-            parsed_url.host,
-            parsed_url.port,
-            allow_local=self.allow_local_hosts,
-        )
+        #
+        # Bound DNS resolution by the request deadline: getaddrinfo is otherwise
+        # unbounded (a tarpit nameserver could stall a worker -- and tie up an
+        # event-loop executor thread -- far past timeout_seconds), so the
+        # documented "overall deadline" must cover it too.
+        try:
+            connect_addresses = await asyncio.wait_for(
+                validate_target(
+                    parsed_url.host,
+                    parsed_url.port,
+                    allow_local=self.allow_local_hosts,
+                ),
+                timeout=self.timeout_seconds,
+            )
+        except TimeoutError as e:
+            raise GopherProtocolError(
+                f"Timed out resolving host '{parsed_url.host}'"
+            ) from e
 
         # Politeness: space out requests to the same (often small) host.
         await self._rate_limiter.acquire(parsed_url.host)

--- a/src/gopher_mcp/ratelimit.py
+++ b/src/gopher_mcp/ratelimit.py
@@ -48,6 +48,12 @@ class RateLimiter:
         self._lock = asyncio.Lock()
         self._clock = clock
         self._sleep = sleep
+        # When throttling is enabled, hosts visited once would otherwise live in
+        # ``_next_allowed`` forever (an "open-world" fetcher sees unbounded
+        # distinct hosts). Once the map grows past this many entries, sweep out
+        # hosts whose reservation has already elapsed (they impose no future
+        # constraint, so dropping them is behaviour-preserving).
+        self._sweep_threshold = 1024
 
     async def acquire(self, host: str) -> None:
         """Block until a request to ``host`` is permitted.
@@ -65,6 +71,14 @@ class RateLimiter:
             base = allowed_at if wait > 0 else now
             if self.min_interval > 0:
                 self._next_allowed[host] = base + self.min_interval
+                # Bound memory: drop hosts whose reserved time has already
+                # passed. The host just reserved above is in the future, so it
+                # survives. Amortized via the threshold so the common path stays
+                # O(1).
+                if len(self._next_allowed) > self._sweep_threshold:
+                    self._next_allowed = {
+                        h: t for h, t in self._next_allowed.items() if t > now
+                    }
             elif wait <= 0:
                 # Disabled and the penalty (if any) has elapsed -- forget the host.
                 self._next_allowed.pop(host, None)

--- a/src/gopher_mcp/server.py
+++ b/src/gopher_mcp/server.py
@@ -86,6 +86,15 @@ mcp = FastMCP("gopher-mcp", instructions=SERVER_INSTRUCTIONS)
 MAX_BATCH_URLS = 50
 BATCH_CONCURRENCY = 5
 
+# LLM-facing messages for the *defensive* catch-all paths. ``client.fetch``
+# normally returns a sanitized ErrorResult rather than raising, so reaching these
+# means an unexpected internal exception -- whose ``str(e)`` can carry local
+# paths or library internals. Log the detail server-side, return a generic
+# message to the model. (Validation errors keep their specific message: those are
+# safe Pydantic messages the model needs to correct its input.)
+_GENERIC_FETCH_ERROR = "An unexpected error occurred while fetching the resource."
+_GENERIC_SETUP_ERROR = "Failed to initialize the fetch client."
+
 
 class ClientManager:
     """Singleton manager for Gopher and Gemini client instances."""
@@ -166,6 +175,7 @@ class ClientManager:
                     allow_local_hosts=gemini_config.allow_local_hosts,
                     tofu_enabled=gemini_config.tofu_enabled,
                     tofu_storage_path=tofu_path,
+                    tofu_reject_expired=gemini_config.tofu_reject_expired,
                     client_certs_enabled=gemini_config.client_certs_enabled,
                     client_certs_storage_path=client_certs_path,
                     max_rendered_chars=gemini_config.max_rendered_chars,
@@ -192,16 +202,13 @@ class ClientManager:
             self._gemini_client = None
 
 
-# Global client manager instance
-_client_manager: ClientManager | None = None
-
-
 async def get_client_manager() -> ClientManager:
-    """Get or create the global client manager instance."""
-    global _client_manager
-    if _client_manager is None:
-        _client_manager = await ClientManager.get_instance()
-    return _client_manager
+    """Get or create the singleton client manager instance.
+
+    ``ClientManager`` already provides a properly locked singleton, so this is a
+    thin wrapper kept for call-site readability (and as a patch point in tests).
+    """
+    return await ClientManager.get_instance()
 
 
 @mcp.tool(annotations=_FETCH_ANNOTATIONS, title="Fetch Gopher resource")
@@ -239,7 +246,7 @@ async def gopher_fetch(url: _GopherUrl) -> dict[str, Any]:
     except Exception as e:  # defensive: client.fetch normally returns ErrorResult
         logger.error("Gopher fetch failed", url=url, error=str(e))
         return ErrorResult(
-            error={"code": "FETCH_ERROR", "message": str(e)},
+            error={"code": "FETCH_ERROR", "message": _GENERIC_FETCH_ERROR},
             requestInfo={"url": url},
         ).model_dump()
 
@@ -288,7 +295,7 @@ async def gemini_fetch(url: _GeminiUrl, input: _GeminiInput = None) -> dict[str,
     except Exception as e:  # defensive: client.fetch normally returns ErrorResult
         logger.error("Gemini fetch failed", url=url, error=str(e))
         return GeminiErrorResult(
-            error={"code": "FETCH_ERROR", "message": str(e)},
+            error={"code": "FETCH_ERROR", "message": _GENERIC_FETCH_ERROR},
             requestInfo={"url": url},
         ).model_dump()
 
@@ -302,26 +309,27 @@ async def gopher_batch_fetch(urls: list[str]) -> list[dict[str, Any]]:
     menu items or related resources at once.
 
     Args:
-        urls: List of Gopher URLs to fetch
+        urls: List of Gopher URLs to fetch (at most 50 per call)
 
     Returns:
-        List of responses in the same order as the input URLs
+        List of responses in the same order and of the same length as the input
+        URLs, so callers can zip responses to requests by index.
 
     """
     from .models import ErrorResult
 
     # Over-limit is a sanitized, structured error -- not a raised exception that
-    # FastMCP would surface to the model as a raw ToolError.
+    # FastMCP would surface to the model as a raw ToolError. Return ONE error per
+    # input URL so the response stays index-aligned with the request (a single
+    # element would silently break a caller zipping responses to URLs).
     if len(urls) > MAX_BATCH_URLS:
+        message = f"Too many URLs in batch request: {len(urls)} (max {MAX_BATCH_URLS})"
         return [
             ErrorResult(
-                error={
-                    "code": "INVALID_REQUEST",
-                    "message": f"Too many URLs in batch request: "
-                    f"{len(urls)} (max {MAX_BATCH_URLS})",
-                },
-                requestInfo={},
+                error={"code": "INVALID_REQUEST", "message": message},
+                requestInfo={"url": url},
             ).model_dump()
+            for url in urls
         ]
 
     # Client setup can raise (e.g. a fail-closed corrupt TOFU/cert store);
@@ -333,9 +341,10 @@ async def gopher_batch_fetch(urls: list[str]) -> list[dict[str, Any]]:
         logger.error("Gopher batch fetch setup failed", error=str(e))
         return [
             ErrorResult(
-                error={"code": "FETCH_ERROR", "message": str(e)},
-                requestInfo={},
+                error={"code": "FETCH_ERROR", "message": _GENERIC_SETUP_ERROR},
+                requestInfo={"url": url},
             ).model_dump()
+            for url in urls
         ]
     semaphore = asyncio.Semaphore(BATCH_CONCURRENCY)
 
@@ -352,8 +361,9 @@ async def gopher_batch_fetch(urls: list[str]) -> list[dict[str, Any]]:
                 response = await client.fetch(request.url)
                 return response.model_dump()
             except Exception as e:  # defensive: client.fetch normally never raises
+                logger.error("Gopher batch item failed", url=url, error=str(e))
                 return ErrorResult(
-                    error={"code": "FETCH_ERROR", "message": str(e)},
+                    error={"code": "FETCH_ERROR", "message": _GENERIC_FETCH_ERROR},
                     requestInfo={"url": url},
                 ).model_dump()
 
@@ -371,26 +381,26 @@ async def gemini_batch_fetch(urls: list[str]) -> list[dict[str, Any]]:
     pages or related resources at once.
 
     Args:
-        urls: List of Gemini URLs to fetch
+        urls: List of Gemini URLs to fetch (at most 50 per call)
 
     Returns:
-        List of responses in the same order as the input URLs
+        List of responses in the same order and of the same length as the input
+        URLs, so callers can zip responses to requests by index.
 
     """
     from .models import GeminiErrorResult
 
     # Over-limit is a sanitized, structured error -- not a raised exception that
-    # FastMCP would surface to the model as a raw ToolError.
+    # FastMCP would surface to the model as a raw ToolError. Return ONE error per
+    # input URL so the response stays index-aligned with the request.
     if len(urls) > MAX_BATCH_URLS:
+        message = f"Too many URLs in batch request: {len(urls)} (max {MAX_BATCH_URLS})"
         return [
             GeminiErrorResult(
-                error={
-                    "code": "INVALID_REQUEST",
-                    "message": f"Too many URLs in batch request: "
-                    f"{len(urls)} (max {MAX_BATCH_URLS})",
-                },
-                requestInfo={},
+                error={"code": "INVALID_REQUEST", "message": message},
+                requestInfo={"url": url},
             ).model_dump()
+            for url in urls
         ]
 
     # Client setup can raise (e.g. a fail-closed corrupt TOFU/cert store);
@@ -402,9 +412,10 @@ async def gemini_batch_fetch(urls: list[str]) -> list[dict[str, Any]]:
         logger.error("Gemini batch fetch setup failed", error=str(e))
         return [
             GeminiErrorResult(
-                error={"code": "FETCH_ERROR", "message": str(e)},
-                requestInfo={},
+                error={"code": "FETCH_ERROR", "message": _GENERIC_SETUP_ERROR},
+                requestInfo={"url": url},
             ).model_dump()
+            for url in urls
         ]
     semaphore = asyncio.Semaphore(BATCH_CONCURRENCY)
 
@@ -421,8 +432,9 @@ async def gemini_batch_fetch(urls: list[str]) -> list[dict[str, Any]]:
                 response = await client.fetch(request.url)
                 return response.model_dump()
             except Exception as e:  # defensive: client.fetch normally never raises
+                logger.error("Gemini batch item failed", url=url, error=str(e))
                 return GeminiErrorResult(
-                    error={"code": "FETCH_ERROR", "message": str(e)},
+                    error={"code": "FETCH_ERROR", "message": _GENERIC_FETCH_ERROR},
                     requestInfo={"url": url},
                 ).model_dump()
 
@@ -432,11 +444,16 @@ async def gemini_batch_fetch(urls: list[str]) -> list[dict[str, Any]]:
 
 
 async def cleanup() -> None:
-    """Cleanup resources."""
-    global _client_manager
-    if _client_manager:
-        await _client_manager.cleanup()
-        _client_manager = None
+    """Cleanup resources and drop the singleton.
+
+    Resetting ``ClientManager._instance`` (the single source of truth) ensures
+    the next ``get_client_manager()`` builds a fresh manager instead of handing
+    back one whose clients were just closed.
+    """
+    instance = ClientManager._instance
+    if instance is not None:
+        await instance.cleanup()
+        ClientManager._instance = None
 
 
 def main() -> None:

--- a/src/gopher_mcp/tofu.py
+++ b/src/gopher_mcp/tofu.py
@@ -3,9 +3,12 @@
 import contextlib
 import hmac
 import json
+import os
 import time
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import structlog
@@ -14,12 +17,38 @@ from .models import TOFUEntry
 from .ssrf import normalize_host
 from .utils import atomic_write_json, get_home_directory
 
+# fcntl is POSIX-only. The explicit ``ModuleType | None`` annotation keeps the
+# ``is None`` guard reachable under mypy's warn_unreachable (the import always
+# succeeds on POSIX, so without it mypy would treat the None branch as dead).
+fcntl: ModuleType | None
+try:
+    import fcntl  # POSIX-only advisory file locking
+except ImportError:  # pragma: no cover - non-POSIX (e.g. Windows)
+    fcntl = None
+
 logger = structlog.get_logger(__name__)
 
 # Minimum seconds between best-effort last_seen flushes to disk. A new pin or a
 # fingerprint change always persists immediately; only the read-path last_seen
 # touch is throttled.
 SAVE_THROTTLE_SECONDS = 60.0
+
+
+def _canon_fingerprint(fingerprint: str) -> str:
+    """Canonicalize a SHA-256 certificate fingerprint to one comparable form.
+
+    The wire path always produces ``hashlib.sha256(...).hexdigest()`` (lowercase,
+    no separators), but users pin certs by pasting the conventional
+    ``openssl x509 -fingerprint`` / browser form (``sha256:AB:CD:...`` or
+    ``AB:CD:...``). Storing those verbatim makes the constant-time compare never
+    match, turning the user's own pin into a permanent CERTIFICATE_CHANGED
+    denial. Normalize both stored and presented fingerprints through here so the
+    representation can never cause a spurious mismatch.
+    """
+    fingerprint = fingerprint.strip()
+    if fingerprint.lower().startswith("sha256:"):
+        fingerprint = fingerprint[7:]
+    return fingerprint.replace(":", "").lower()
 
 
 def _parse_expiry(cert_info: dict[str, Any] | None) -> float | None:
@@ -51,6 +80,35 @@ def _parse_expiry(cert_info: dict[str, Any] | None) -> float | None:
     return None
 
 
+def _parse_not_before(cert_info: dict[str, Any] | None) -> float | None:
+    """Extract a certificate's notBefore (UNIX timestamp) from cert info.
+
+    Mirrors :func:`_parse_expiry`; the gemini_tls layer parses the DER under
+    CERT_NONE, so ``not_before_timestamp`` is the authoritative source.
+    """
+    if not cert_info:
+        return None
+    if "not_before_timestamp" in cert_info:
+        try:
+            return float(cert_info["not_before_timestamp"])
+        except (TypeError, ValueError):
+            return None
+    if "notBefore" in cert_info:
+        try:
+            return (
+                datetime.strptime(cert_info["notBefore"], "%b %d %H:%M:%S %Y %Z")
+                .replace(tzinfo=UTC)
+                .timestamp()
+            )
+        except ValueError:
+            logger.warning(
+                "Failed to parse certificate notBefore",
+                not_before=cert_info["notBefore"],
+            )
+            return None
+    return None
+
+
 class TOFUValidationError(Exception):
     """Exception raised for TOFU validation failures."""
 
@@ -59,14 +117,33 @@ class TOFUValidationError(Exception):
         self.entry = entry
 
 
+class TOFUExpiredError(TOFUValidationError):
+    """A certificate is outside its validity window (expired / not yet valid).
+
+    A *distinct* subclass so callers can report this accurately: the cert still
+    matches the pinned fingerprint, so surfacing it as a generic
+    "certificate changed / does not match" would wrongly imply a key rotation or
+    MITM and send an operator chasing a phantom. Only raised when
+    ``reject_expired`` is enabled.
+    """
+
+
 class TOFUManager:
     """Trust-on-First-Use certificate validation manager."""
 
-    def __init__(self, storage_path: str | None = None):
+    def __init__(
+        self, storage_path: str | None = None, *, reject_expired: bool = False
+    ):
         """Initialize TOFU manager.
 
         Args:
             storage_path: Path to TOFU storage file (default: ~/.gemini/tofu.json)
+            reject_expired: When True, a certificate outside its validity window
+                (already expired, or not yet valid on first use) fails CLOSED
+                instead of being accepted with a warning. Defaults to False to
+                preserve the conventional Gemini TOFU behaviour where the
+                fingerprint pin -- not the validity window -- is the real
+                authenticator.
         """
         if storage_path is None:
             home_dir = get_home_directory()
@@ -81,6 +158,7 @@ class TOFUManager:
             storage_path = str(gemini_dir / "tofu.json")
 
         self.storage_path = storage_path
+        self.reject_expired = reject_expired
         self._entries: dict[str, TOFUEntry] = {}
         # Throttle best-effort last_seen flushes (see validate_certificate).
         self._last_save_time = 0.0
@@ -112,6 +190,11 @@ class TOFUManager:
             with Path(self.storage_path).open(encoding="utf-8") as f:
                 data = json.load(f)
             entries = {key: TOFUEntry(**entry_data) for key, entry_data in data.items()}
+            # Canonicalize any legacy / hand-edited fingerprints so a store
+            # written before normalization (or edited by a human in colon form)
+            # still matches the wire digest.
+            for entry in entries.values():
+                entry.fingerprint = _canon_fingerprint(entry.fingerprint)
         except Exception as e:
             logger.error("TOFU storage is corrupt or unreadable", error=str(e))
             raise TOFUValidationError(
@@ -126,16 +209,73 @@ class TOFUManager:
             storage_path=self.storage_path,
         )
 
-    def _save_entries(self) -> None:
-        """Save TOFU entries to storage."""
-        try:
-            # Convert entries to dict for JSON serialization
-            data = {}
-            for key, entry in self._entries.items():
-                data[key] = entry.model_dump()
+    @contextlib.contextmanager
+    def _store_lock(self) -> Iterator[None]:
+        """Best-effort exclusive cross-process lock around a store mutation.
 
-            # Use atomic write function
-            atomic_write_json(self.storage_path, data)
+        Serializes the read-merge-write cycle so two server instances sharing
+        the same store file can't lose each other's pins. A no-op where
+        ``fcntl`` is unavailable (e.g. Windows): the atomic rename still
+        prevents torn files there; only the cross-process merge guarantee is
+        relaxed.
+        """
+        if fcntl is None:  # pragma: no cover - exercised only on non-POSIX
+            yield
+            return
+        lock = fcntl  # local so mypy narrows ModuleType | None -> ModuleType
+        lock_path = self.storage_path + ".lock"
+        Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            lock.flock(fd, lock.LOCK_EX)
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                lock.flock(fd, lock.LOCK_UN)
+            os.close(fd)
+
+    def _read_disk_entries(self) -> dict[str, TOFUEntry]:
+        """Read the current on-disk entries (canonicalized) for merging.
+
+        Returns ``{}`` if the file is missing or unreadable. Unlike
+        :meth:`_load_entries` this does NOT fail closed: a transiently bad file
+        must not block persisting our good in-memory state (the next write
+        repairs it). Startup fail-closed behaviour is unchanged.
+        """
+        path = Path(self.storage_path)
+        if not path.exists():
+            return {}
+        try:
+            with path.open(encoding="utf-8") as f:
+                data = json.load(f)
+            entries = {key: TOFUEntry(**val) for key, val in data.items()}
+        except Exception as e:
+            logger.warning("Ignoring unreadable TOFU store during merge", error=str(e))
+            return {}
+        for entry in entries.values():
+            entry.fingerprint = _canon_fingerprint(entry.fingerprint)
+        return entries
+
+    def _save_entries(self, *, removed_keys: set[str] | None = None) -> None:
+        """Persist entries, merging with concurrent on-disk changes.
+
+        Holds an exclusive cross-process lock while it re-reads the store,
+        unions it with our in-memory entries (ours win for shared keys), drops
+        any keys this operation explicitly removed, then atomically writes. This
+        keeps a second instance from silently clobbering a pin we just wrote
+        (and vice versa). ``removed_keys`` must be passed for deletions so the
+        merge doesn't resurrect them from disk.
+        """
+        try:
+            with self._store_lock():
+                merged = {**self._read_disk_entries(), **self._entries}
+                if removed_keys:
+                    for key in removed_keys:
+                        merged.pop(key, None)
+                self._entries = merged
+
+                data = {key: entry.model_dump() for key, entry in merged.items()}
+                atomic_write_json(self.storage_path, data)
 
             logger.debug("TOFU entries saved", count=len(self._entries))
         except Exception as e:
@@ -166,15 +306,38 @@ class TOFUManager:
         key = self._get_key(host, port)
         current_time = time.time()
 
-        # Clean fingerprint format (remove sha256: prefix if present)
-        if cert_fingerprint.startswith("sha256:"):
-            cert_fingerprint = cert_fingerprint[7:]
+        # Normalize to one canonical form so a colon/uppercase representation
+        # can never cause a spurious mismatch against the wire digest.
+        cert_fingerprint = _canon_fingerprint(cert_fingerprint)
 
         existing_entry = self._entries.get(key)
 
         if existing_entry is None:
             # First time seeing this host:port - trust on first use
             expires = _parse_expiry(cert_info)
+            not_before = _parse_not_before(cert_info)
+
+            # A cert outside its validity window on first contact is a strong
+            # signal something is off. The fingerprint pin is fixed for the
+            # life of the cert (same fingerprint == same cert), so checking the
+            # window once, here, covers every subsequent connection.
+            window_problem: str | None = None
+            if expires is not None and expires < current_time:
+                window_problem = "already expired"
+            elif not_before is not None and not_before > current_time:
+                window_problem = "not yet valid"
+
+            if window_problem and self.reject_expired:
+                logger.warning(
+                    "Refusing to pin certificate outside its validity window",
+                    host=host,
+                    port=port,
+                    problem=window_problem,
+                )
+                raise TOFUExpiredError(
+                    f"Certificate for {host}:{port} is {window_problem}; refusing "
+                    "to trust on first use (reject_expired is enabled)"
+                )
 
             new_entry = TOFUEntry(
                 host=host,
@@ -197,12 +360,13 @@ class TOFUManager:
             )
 
             message = f"New certificate for {host}:{port} trusted on first use"
-            # Pin it regardless, but flag a cert that is ALREADY expired on first
-            # contact -- a strong signal that something is off.
-            if expires is not None and expires < current_time:
-                message += " (warning: certificate is already expired)"
+            if window_problem:
+                message += f" (warning: certificate is {window_problem})"
                 logger.warning(
-                    "First-use certificate is already expired", host=host, port=port
+                    "First-use certificate is outside its validity window",
+                    host=host,
+                    port=port,
+                    problem=window_problem,
                 )
             return True, message
 
@@ -214,7 +378,7 @@ class TOFUManager:
                     f"Certificate for {host}:{port} has changed!\n"
                     f"Previous: {existing_entry.fingerprint[:16]}...\n"
                     f"Current:  {cert_fingerprint[:16]}...\n"
-                    f"First seen: {datetime.fromtimestamp(existing_entry.first_seen)}\n"
+                    f"First seen: {datetime.fromtimestamp(existing_entry.first_seen, tz=UTC)}\n"
                     f"This could indicate a security issue."
                 )
 
@@ -238,10 +402,14 @@ class TOFUManager:
                 self._save_entries()
                 self._last_save_time = current_time
 
-            # Check if certificate is expired
+            # Check if certificate is expired. By default this is advisory only
+            # (the fingerprint pin is the real authenticator under TOFU); a
+            # deployment can opt into fail-closed via reject_expired.
             if existing_entry.is_expired(current_time):
                 warning = f"Certificate for {host}:{port} has expired"
                 logger.warning("Certificate expired", host=host, port=port)
+                if self.reject_expired:
+                    raise TOFUExpiredError(warning, existing_entry)
                 return True, warning
 
             logger.debug(
@@ -276,9 +444,8 @@ class TOFUManager:
         key = self._get_key(host, port)
         current_time = time.time()
 
-        # Clean fingerprint format
-        if cert_fingerprint.startswith("sha256:"):
-            cert_fingerprint = cert_fingerprint[7:]
+        # Normalize to one canonical form (see _canon_fingerprint).
+        cert_fingerprint = _canon_fingerprint(cert_fingerprint)
 
         existing_entry = self._entries.get(key)
 
@@ -329,7 +496,9 @@ class TOFUManager:
 
         if key in self._entries:
             del self._entries[key]
-            self._save_entries()
+            # Pass the removed key so the merge-with-disk step doesn't resurrect
+            # it from a stale on-disk copy.
+            self._save_entries(removed_keys={key})
 
             logger.info("Certificate removed", host=host, port=port)
             return True
@@ -361,7 +530,7 @@ class TOFUManager:
             del self._entries[key]
 
         if expired_keys:
-            self._save_entries()
+            self._save_entries(removed_keys=set(expired_keys))
             logger.info("Expired certificates removed", count=len(expired_keys))
 
         return len(expired_keys)

--- a/src/gopher_mcp/utils.py
+++ b/src/gopher_mcp/utils.py
@@ -3,6 +3,7 @@
 import contextlib
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -49,15 +50,27 @@ def atomic_write_json(file_path: str, data: Any) -> None:
     # Ensure directory exists
     Path(file_path).parent.mkdir(parents=True, exist_ok=True)
 
-    # Create temporary file in the same directory as the target
+    # Create temporary file in the same directory as the target. Capture its
+    # path first so the cleanup below can always reach it -- every fallible step
+    # after creation (json.dump, flush, fsync, rename, chmod, dir fsync) runs
+    # inside the single try whose ``except`` unlinks the temp file, so a failure
+    # mid-write (e.g. ENOSPC surfacing on flush/fsync) can't orphan a .tmp file.
     temp_dir = Path(file_path).parent
-    with tempfile.NamedTemporaryFile(
-        mode="w", dir=temp_dir, delete=False, suffix=".tmp"
-    ) as temp_file:
-        json.dump(data, temp_file, indent=2)
-        temp_path = temp_file.name
-
+    temp_path: str | None = None
     try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=temp_dir, delete=False, suffix=".tmp"
+        ) as temp_file:
+            temp_path = temp_file.name
+            json.dump(data, temp_file, indent=2)
+            # Durability: force the bytes to stable storage BEFORE the rename.
+            # ``rename`` is atomic only for *visibility* -- without the fsync a
+            # crash/power-loss after the rename can leave a zero-length or
+            # truncated file, which the deliberately fail-closed TOFU loader then
+            # refuses to start with. Flush the Python buffer, then the OS buffer.
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+
         # On Windows, we need to remove the target file first if it exists
         if os.name == "nt" and Path(file_path).exists():
             Path(file_path).unlink()
@@ -69,11 +82,21 @@ def atomic_write_json(file_path: str, data: Any) -> None:
         # dir's 0700 (whose chmod is best-effort). No-op / harmless on Windows.
         with contextlib.suppress(OSError):
             Path(file_path).chmod(0o600)
+        # fsync the directory so the rename itself is durable (POSIX). Best
+        # effort: not supported on every platform/FS, and a no-op on Windows.
+        with contextlib.suppress(OSError, AttributeError):
+            dir_fd = os.open(str(temp_dir), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
     except Exception:
-        # Clean up temporary file if rename fails (ignore cleanup failures so
-        # the original error is preserved).
-        with contextlib.suppress(Exception):
-            Path(temp_path).unlink()
+        # Clean up the temp file on any failure (ignore cleanup failures so the
+        # original error is preserved). After a successful rename temp_path no
+        # longer exists, so the unlink is a harmless no-op.
+        if temp_path is not None:
+            with contextlib.suppress(Exception):
+                Path(temp_path).unlink()
         raise
 
 
@@ -154,6 +177,17 @@ def parse_gopher_url(url: str) -> GopherURL:
         search = unquote(search_part)
     else:
         selector = unquote(raw_selector)
+
+    # Fail closed on raw control bytes that percent-decoding can introduce. A
+    # C0/DEL byte (CR/LF/TAB/NUL/ESC/...) in the selector or search would inject
+    # extra fields or terminate the single Gopher request line (which the
+    # transport builds as ``selector<TAB>search\r\n``). The client re-checks
+    # this too, but the parser must not depend on a separate validation pass --
+    # mirror parse_gemini_url and reject here.
+    if re.search(r"[\x00-\x1f\x7f]", selector):
+        raise ValueError("Selector must not contain control characters")
+    if search is not None and re.search(r"[\x00-\x1f\x7f]", search):
+        raise ValueError("Search query must not contain control characters")
 
     return GopherURL(
         host=host,
@@ -400,24 +434,6 @@ def gopher_type_category(gopher_type: str) -> str:
     types default to ``"text"`` (best-effort), matching historical behaviour.
     """
     return _GOPHER_TYPE_CATEGORY.get(gopher_type, "text")
-
-
-def validate_gopher_response(content: bytes, max_size: int) -> None:
-    """Validate a Gopher response.
-
-    Args:
-        content: Response content
-        max_size: Maximum allowed size
-
-    Raises:
-        ValueError: If response is invalid
-
-    """
-    if len(content) > max_size:
-        raise ValueError(f"Response too large: {len(content)} bytes (max {max_size})")
-
-    # Additional validation could be added here
-    # e.g., checking for proper termination markers
 
 
 # ============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,17 +35,14 @@ def _stub_dns(monkeypatch: pytest.MonkeyPatch) -> None:
 def _reset_client_manager_singleton():
     """Reset the global client-manager singleton around every test.
 
-    The manager is a module/class-level singleton, so an instance created by one
-    test would otherwise leak into the next (an ordering dependency). This is the
+    The manager is a class-level singleton, so an instance created by one test
+    would otherwise leak into the next (an ordering dependency). This is the
     safety net so a forgotten manual reset can't contaminate later tests.
     """
-    import gopher_mcp.server
     from gopher_mcp.server import ClientManager
 
-    gopher_mcp.server._client_manager = None
     ClientManager._instance = None
     yield
-    gopher_mcp.server._client_manager = None
     ClientManager._instance = None
 
 

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -175,6 +175,35 @@ class TestGeminiClientFetch:
             mock_parse.assert_called_once_with("gemini://example.com/")
 
     @pytest.mark.asyncio
+    async def test_dns_resolution_is_bounded_by_request_timeout(self):
+        """A hanging resolver must not exceed the request deadline. DNS was
+        previously outside the timeout envelope, so a tarpit nameserver could
+        stall a worker far past timeout_seconds."""
+        import asyncio
+
+        client = GeminiClient(
+            timeout_seconds=0.05,
+            cache_enabled=False,
+            tofu_enabled=False,
+            client_certs_enabled=False,
+        )
+
+        async def slow_validate(*args, **kwargs):
+            await asyncio.sleep(5)
+            return ["93.184.216.34"]
+
+        with patch(
+            "gopher_mcp.gemini_client.validate_target", side_effect=slow_validate
+        ):
+            result = await asyncio.wait_for(
+                client.fetch("gemini://example.org/"), timeout=1.0
+            )
+
+        assert isinstance(result, GeminiErrorResult)
+        assert result.error["code"] == "FETCH_ERROR"
+        await client.close()
+
+    @pytest.mark.asyncio
     async def test_missing_fingerprint_fails_closed_without_sending(self):
         """The most security-critical TOFU branch: when TLS yields no certificate
         fingerprint, the request must NOT be sent to the unverified peer."""
@@ -193,6 +222,48 @@ class TestGeminiClientFetch:
         assert isinstance(result, GeminiErrorResult)
         assert result.error["code"] == "CERTIFICATE_CHANGED"
         client.tls_client.send_data.assert_not_awaited()  # never reached the wire
+
+    @pytest.mark.asyncio
+    async def test_expired_pin_reports_certificate_expired_not_changed(self):
+        """With reject_expired, an expired-but-MATCHING pin must report
+        CERTIFICATE_EXPIRED -- not CERTIFICATE_CHANGED, which would falsely imply
+        the cert no longer matches and send an operator chasing a phantom MITM."""
+        import tempfile
+        from pathlib import Path as _Path
+
+        from gopher_mcp.models import TOFUEntry
+
+        with tempfile.TemporaryDirectory() as d:
+            client = GeminiClient(
+                client_certs_enabled=False,
+                tofu_reject_expired=True,
+                tofu_storage_path=str(_Path(d) / "tofu.json"),
+            )
+            assert client.tofu_manager is not None
+            # Pre-pin an already-expired cert with a known fingerprint.
+            client.tofu_manager._entries["example.com:1965"] = TOFUEntry(
+                host="example.com",
+                port=1965,
+                fingerprint="abc",
+                first_seen=1.0,
+                last_seen=1.0,
+                expires=100.0,
+            )
+
+            client.tls_client.connect = AsyncMock(  # type: ignore[method-assign]
+                return_value=(Mock(), {"cert_fingerprint": "abc", "peer_cert_info": {}})
+            )
+            client.tls_client.send_data = AsyncMock()  # type: ignore[method-assign]
+            client.tls_client.receive_data = AsyncMock()  # type: ignore[method-assign]
+            client.tls_client.close = AsyncMock()  # type: ignore[method-assign]
+
+            result = await client.fetch("gemini://example.com/")
+
+        assert isinstance(result, GeminiErrorResult)
+        assert result.error["code"] == "CERTIFICATE_EXPIRED"
+        # The accurate message must not claim the cert "changed"/"does not match".
+        assert "does not match" not in result.error["message"].lower()
+        client.tls_client.send_data.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_fetch_with_cache_hit(self):

--- a/tests/test_gopher_client.py
+++ b/tests/test_gopher_client.py
@@ -816,3 +816,29 @@ class TestFetchContentMethod:
             pytest.raises(GopherProtocolError, match="Connection failed"),
         ):
             await client._fetch_content(parsed_url)
+
+    @pytest.mark.asyncio
+    async def test_dns_resolution_is_bounded_by_request_timeout(self):
+        """A hanging resolver must not exceed the request deadline. DNS was
+        previously outside the timeout envelope, so a tarpit nameserver could
+        stall a worker far past timeout_seconds."""
+        import asyncio
+
+        client = GopherClient(timeout_seconds=0.05, cache_enabled=False)
+
+        async def slow_validate(*args, **kwargs):
+            await asyncio.sleep(5)
+            return ["93.184.216.34"]
+
+        with patch(
+            "gopher_mcp.gopher_client.validate_target", side_effect=slow_validate
+        ):
+            # Outer guard fails the test if fetch hangs on DNS instead of
+            # honouring its own deadline.
+            result = await asyncio.wait_for(
+                client.fetch("gopher://example.com/1/"), timeout=1.0
+            )
+
+        assert isinstance(result, ErrorResult)
+        assert result.error["code"] == "FETCH_ERROR"
+        await client.close()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,9 +23,6 @@ from gopher_mcp.server import (
 
 def clear_client_manager():
     """Helper to clear client manager singleton."""
-    import gopher_mcp.server
-
-    gopher_mcp.server._client_manager = None
     ClientManager._instance = None
 
 

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -65,3 +65,34 @@ class TestRateLimiterAcquire:
         await rl.acquire("slow.example")
         sleep.assert_awaited_once()
         assert sleep.await_args.args[0] == pytest.approx(5.0)
+
+    async def test_stale_host_entries_are_swept_when_throttling(self):
+        """With throttling enabled, hosts visited once must not accumulate
+        forever -- entries whose next-allowed time has elapsed are swept."""
+        clock = _FakeClock(100.0)
+        sleep = AsyncMock()
+        rl = RateLimiter(60, clock=clock, sleep=sleep)  # 1s interval
+        rl._sweep_threshold = 10  # keep the test small
+
+        # Visit many distinct hosts, advancing the clock so each prior host's
+        # reservation has long elapsed by the time the sweep runs.
+        for i in range(100):
+            clock.t = 100.0 + i * 10.0
+            await rl.acquire(f"host{i}.example")
+
+        # Without sweeping this would be 100; it must stay bounded near the
+        # threshold (only the just-reserved host is still "in the future").
+        assert len(rl._next_allowed) <= rl._sweep_threshold + 1
+
+    async def test_sweep_keeps_hosts_with_live_reservations(self):
+        """The sweep must not drop hosts that still owe a future wait."""
+        clock = _FakeClock(100.0)
+        sleep = AsyncMock()
+        rl = RateLimiter(60, clock=clock, sleep=sleep)  # 1s interval
+        rl._sweep_threshold = 5
+
+        # All reservations are live (clock never advances), so none are stale.
+        for i in range(50):
+            await rl.acquire(f"host{i}.example")
+
+        assert len(rl._next_allowed) == 50

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,10 +19,7 @@ from gopher_mcp.server import (
 
 
 def clear_client_manager():
-    """Helper to clear both module-level and class-level client manager instances."""
-    import gopher_mcp.server
-
-    gopher_mcp.server._client_manager = None
+    """Helper to clear the client-manager singleton."""
     ClientManager._instance = None
     # Also reset the config so it picks up new environment variables
     reset_config()
@@ -143,9 +140,10 @@ class TestGopherFetch:
 
     @pytest.mark.asyncio
     async def test_gopher_fetch_client_error(self):
-        """A client failure is returned as a sanitized FETCH_ERROR, not raised."""
+        """An unexpected client failure is a sanitized FETCH_ERROR whose
+        message does not leak internal exception detail to the LLM."""
         mock_client = AsyncMock()
-        mock_client.fetch.side_effect = Exception("Connection failed")
+        mock_client.fetch.side_effect = Exception("/home/u/.gemini/secret boom")
 
         mock_manager = AsyncMock()
         mock_manager.get_gopher_client.return_value = mock_client
@@ -154,7 +152,8 @@ class TestGopherFetch:
             result = await gopher_fetch("gopher://example.com/0/test.txt")
 
         assert result["error"]["code"] == "FETCH_ERROR"
-        assert "Connection failed" in result["error"]["message"]
+        assert "secret" not in result["error"]["message"]
+        assert "boom" not in result["error"]["message"]
 
 
 class TestGopherBatchFetch:
@@ -245,14 +244,17 @@ class TestGopherBatchFetch:
 
     @pytest.mark.asyncio
     async def test_gopher_batch_fetch_too_many_urls(self):
-        """A batch larger than MAX_BATCH_URLS is rejected."""
+        """Over-limit preserves the order/length contract: one error per URL."""
         from gopher_mcp.server import MAX_BATCH_URLS, gopher_batch_fetch
 
         urls = [f"gopher://example.com/0/{i}" for i in range(MAX_BATCH_URLS + 1)]
         results = await gopher_batch_fetch(urls)
-        assert len(results) == 1
-        assert results[0]["error"]["code"] == "INVALID_REQUEST"
+        # Same length as input so a model can zip responses to URLs by index.
+        assert len(results) == len(urls)
+        assert all(r["error"]["code"] == "INVALID_REQUEST" for r in results)
         assert "Too many URLs" in results[0]["error"]["message"]
+        assert results[0]["request_info"]["url"] == urls[0]
+        assert results[-1]["request_info"]["url"] == urls[-1]
 
     @pytest.mark.asyncio
     async def test_gopher_batch_fetch_setup_failure_returns_error(self):
@@ -354,14 +356,16 @@ class TestGeminiBatchFetch:
 
     @pytest.mark.asyncio
     async def test_gemini_batch_fetch_too_many_urls(self):
-        """A batch larger than MAX_BATCH_URLS is rejected."""
+        """Over-limit preserves the order/length contract: one error per URL."""
         from gopher_mcp.server import MAX_BATCH_URLS, gemini_batch_fetch
 
         urls = [f"gemini://example.org/{i}" for i in range(MAX_BATCH_URLS + 1)]
         results = await gemini_batch_fetch(urls)
-        assert len(results) == 1
-        assert results[0]["error"]["code"] == "INVALID_REQUEST"
+        assert len(results) == len(urls)
+        assert all(r["error"]["code"] == "INVALID_REQUEST" for r in results)
         assert "Too many URLs" in results[0]["error"]["message"]
+        assert results[0]["request_info"]["url"] == urls[0]
+        assert results[-1]["request_info"]["url"] == urls[-1]
 
     @pytest.mark.asyncio
     async def test_gemini_batch_fetch_setup_failure_returns_error(self):
@@ -394,10 +398,11 @@ class TestCleanup:
         # Cleanup should close clients
         await cleanup()
 
-        # Verify cleanup was called
-        import gopher_mcp.server
-
-        assert gopher_mcp.server._client_manager is None
+        # The class singleton is the single source of truth and must be reset,
+        # so the next call builds a fresh manager rather than handing back the
+        # one whose clients were just closed.
+        assert ClientManager._instance is None
+        assert await get_client_manager() is not manager
 
     @pytest.mark.asyncio
     async def test_cleanup_without_clients(self):
@@ -701,9 +706,9 @@ class TestGeminiFetch:
 
     @pytest.mark.asyncio
     async def test_gemini_fetch_client_error(self):
-        """Test gemini fetch when client raises an error."""
+        """An unexpected client failure must not leak exception detail."""
         mock_client = AsyncMock()
-        mock_client.fetch.side_effect = Exception("Connection failed")
+        mock_client.fetch.side_effect = Exception("/home/u/.gemini/secret boom")
 
         mock_manager = AsyncMock()
         mock_manager.get_gemini_client.return_value = mock_client
@@ -712,4 +717,5 @@ class TestGeminiFetch:
             result = await gemini_fetch("gemini://example.org/")
 
         assert result["error"]["code"] == "FETCH_ERROR"
-        assert "Connection failed" in result["error"]["message"]
+        assert "secret" not in result["error"]["message"]
+        assert "boom" not in result["error"]["message"]

--- a/tests/test_tofu.py
+++ b/tests/test_tofu.py
@@ -9,6 +9,7 @@ import pytest
 
 from gopher_mcp.models import TOFUEntry
 from gopher_mcp.tofu import (
+    TOFUExpiredError,
     TOFUManager,
     TOFUValidationError,
 )
@@ -239,6 +240,130 @@ class TestTOFUManager:
             assert warning is not None
             assert "expired" in warning.lower()
 
+    def test_first_use_not_yet_valid_warns(self):
+        """A cert whose notBefore is in the future is pinned but flagged."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            manager = TOFUManager(storage_path)
+
+            cert_info = {"not_before_timestamp": 2000.0}
+            with patch("time.time", return_value=1000.0):
+                is_valid, warning = manager.validate_certificate(
+                    "example.com", 1965, "abc123", cert_info
+                )
+
+            assert is_valid is True
+            assert warning is not None
+            assert "not yet valid" in warning.lower()
+
+    def test_first_use_out_of_window_rejected_when_reject_expired(self):
+        """With reject_expired, a not-yet-valid cert is refused and not pinned."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            manager = TOFUManager(storage_path, reject_expired=True)
+
+            cert_info = {"not_before_timestamp": 2000.0}
+            with patch("time.time", return_value=1000.0):
+                with pytest.raises(TOFUExpiredError):
+                    manager.validate_certificate(
+                        "example.com", 1965, "abc123", cert_info
+                    )
+
+            assert "example.com:1965" not in manager._entries
+
+    def test_expired_pin_warns_but_valid_by_default(self):
+        """Default policy keeps the Gemini-conventional fail-open on expiry."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            manager = TOFUManager(storage_path)
+            manager._entries["example.com:1965"] = TOFUEntry(
+                host="example.com",
+                port=1965,
+                fingerprint="abc123",
+                first_seen=1.0,
+                last_seen=1.0,
+                expires=100.0,
+            )
+
+            with patch("time.time", return_value=200.0):
+                is_valid, warning = manager.validate_certificate(
+                    "example.com", 1965, "abc123"
+                )
+
+            assert is_valid is True
+            assert warning is not None and "expired" in warning.lower()
+
+    def test_expired_pin_fails_closed_when_reject_expired(self):
+        """reject_expired opts a deployment into fail-closed on an expired pin,
+        raising the distinct TOFUExpiredError (a TOFUValidationError subclass) so
+        callers can report it as expiry rather than a fingerprint change."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            manager = TOFUManager(storage_path, reject_expired=True)
+            manager._entries["example.com:1965"] = TOFUEntry(
+                host="example.com",
+                port=1965,
+                fingerprint="abc123",
+                first_seen=1.0,
+                last_seen=1.0,
+                expires=100.0,
+            )
+
+            with patch("time.time", return_value=200.0):
+                with pytest.raises(TOFUExpiredError) as exc_info:
+                    manager.validate_certificate("example.com", 1965, "abc123")
+
+            assert isinstance(exc_info.value, TOFUValidationError)
+            assert "expired" in str(exc_info.value).lower()
+
+    def test_fingerprint_mismatch_warning_renders_first_seen_in_utc(self):
+        """The security warning must render first_seen in UTC, not local time."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            manager = TOFUManager(storage_path)
+            manager._entries["example.com:1965"] = TOFUEntry(
+                host="example.com",
+                port=1965,
+                fingerprint="aa",
+                first_seen=1.0,
+                last_seen=1.0,
+            )
+
+            with pytest.raises(TOFUValidationError) as exc_info:
+                manager.validate_certificate("example.com", 1965, "bb")
+
+            assert "1970-01-01 00:00:01+00:00" in str(exc_info.value)
+
+    def test_save_preserves_pins_written_by_another_instance(self):
+        """A save must merge with on-disk state, not clobber a pin another
+        process/instance wrote after this manager loaded (lost-pin)."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            m1 = TOFUManager(storage_path)
+            m2 = TOFUManager(storage_path)  # both loaded the same (empty) store
+
+            with patch("time.time", return_value=1000.0):
+                m1.validate_certificate("a.example", 1965, "aa")  # m1 pins a
+            with patch("time.time", return_value=1001.0):
+                m2.validate_certificate("b.example", 1965, "bb")  # m2 must keep a
+
+            reloaded = TOFUManager(storage_path)
+            assert "a.example:1965" in reloaded._entries
+            assert "b.example:1965" in reloaded._entries
+
+    def test_remove_persists_across_reload_despite_merge(self):
+        """Removal must win over the merge-with-disk step, not be resurrected."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            manager = TOFUManager(storage_path)
+            with patch("time.time", return_value=1000.0):
+                manager.validate_certificate("a.example", 1965, "aa")
+
+            assert manager.remove_certificate("a.example", 1965) is True
+
+            reloaded = TOFUManager(storage_path)
+            assert "a.example:1965" not in reloaded._entries
+
     def test_last_seen_save_is_throttled(self):
         """A matching re-validation only touches last_seen; it must not rewrite
         the whole trust store to disk on every request (I/O amplification)."""
@@ -301,6 +426,62 @@ class TestTOFUManager:
 
             # Verify last_seen was updated
             assert entry.last_seen == 1234567900
+
+    def test_pin_in_openssl_colon_uppercase_form_matches_wire_digest(self):
+        """A cert pinned in colon-separated uppercase form still matches.
+
+        Users copy fingerprints from ``openssl x509 -fingerprint`` or browser
+        dialogs (``AB:CD:...``), but every live connection presents the
+        canonical lowercase no-colon SHA-256 hexdigest. Without canonicalization
+        the constant-time compare never matches and the user's own pin becomes a
+        permanent CERTIFICATE_CHANGED denial.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            manager = TOFUManager(storage_path)
+
+            manager.update_certificate("example.com", 1965, "AB:CD:EF:01")
+
+            is_valid, _warning = manager.validate_certificate(
+                "example.com", 1965, "abcdef01"
+            )
+            assert is_valid is True
+
+    def test_validate_first_use_canonicalizes_stored_fingerprint(self):
+        """A colon/uppercase fingerprint seen first is stored canonically."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            manager = TOFUManager(storage_path)
+
+            with patch("time.time", return_value=1234567890):
+                manager.validate_certificate("example.com", 1965, "AB:CD:EF:01")
+
+            assert manager._entries["example.com:1965"].fingerprint == "abcdef01"
+
+    def test_legacy_noncanonical_entry_canonicalized_on_load(self):
+        """Hand-edited/legacy entries are canonicalized when loaded."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage_path = str(Path(temp_dir) / "tofu.json")
+            with open(storage_path, "w") as f:
+                json.dump(
+                    {
+                        "example.com:1965": {
+                            "host": "example.com",
+                            "port": 1965,
+                            "fingerprint": "AB:CD:EF:01",
+                            "first_seen": 1.0,
+                            "last_seen": 1.0,
+                            "expires": None,
+                        }
+                    },
+                    f,
+                )
+
+            manager = TOFUManager(storage_path)
+            is_valid, _warning = manager.validate_certificate(
+                "example.com", 1965, "abcdef01"
+            )
+            assert is_valid is True
 
     def test_validate_certificate_fingerprint_mismatch(self):
         """Test validating certificate with fingerprint mismatch."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,13 @@
 """Tests for gopher_mcp.utils module."""
 
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from gopher_mcp.utils import (
+    atomic_write_json,
     format_gopher_url,
     guess_mime_type,
     parse_gopher_menu,
@@ -10,8 +15,33 @@ from gopher_mcp.utils import (
     parse_menu_line,
     sanitize_selector,
     truncate_text,
-    validate_gopher_response,
 )
+
+
+class TestAtomicWriteJson:
+    """Durability and cleanup contract of atomic_write_json."""
+
+    def test_writes_and_reads_back(self):
+        with tempfile.TemporaryDirectory() as d:
+            target = str(Path(d) / "store.json")
+            atomic_write_json(target, {"a": 1, "b": [2, 3]})
+            import json
+
+            assert json.loads(Path(target).read_text()) == {"a": 1, "b": [2, 3]}
+
+    def test_no_orphan_temp_file_when_fsync_fails(self):
+        """A flush/fsync failure (e.g. disk full) must not leave a .tmp orphan --
+        the durability fsync must be inside the cleanup-guarded region."""
+        with tempfile.TemporaryDirectory() as d:
+            target = str(Path(d) / "store.json")
+            with (
+                patch("gopher_mcp.utils.os.fsync", side_effect=OSError("ENOSPC")),
+                pytest.raises(OSError),
+            ):
+                atomic_write_json(target, {"a": 1})
+
+            leftovers = list(Path(d).glob("*.tmp"))
+            assert leftovers == [], f"orphaned temp files: {leftovers}"
 
 
 class TestTruncateText:
@@ -348,32 +378,6 @@ class TestGuessMimeType:
         assert guess_mime_type("9", "file.PDF") == "application/pdf"
 
 
-class TestValidateGopherResponse:
-    """Test validate_gopher_response function."""
-
-    def test_valid_response(self):
-        """Test validating valid response."""
-        content = b"Hello, Gopher!"
-        validate_gopher_response(content, 1024)  # Should not raise
-
-    def test_response_too_large(self):
-        """Test response that is too large."""
-        content = b"x" * 1025
-        with pytest.raises(ValueError) as exc_info:
-            validate_gopher_response(content, 1024)
-        assert "too large" in str(exc_info.value)
-
-    def test_empty_response(self):
-        """Test empty response."""
-        content = b""
-        validate_gopher_response(content, 1024)  # Should not raise
-
-    def test_response_at_limit(self):
-        """Test response at size limit."""
-        content = b"x" * 1024
-        validate_gopher_response(content, 1024)  # Should not raise
-
-
 class TestGopherUrlPortAndSelectorHandling:
     """Regression tests for Gopher URL port/selector parsing fixes."""
 
@@ -403,3 +407,19 @@ class TestGopherUrlPortAndSelectorHandling:
         item = parse_menu_line("0Title\t/sel\texample.com\t²")
         assert item is not None
         assert item.port == 70
+
+    def test_percent_encoded_crlf_in_selector_is_rejected(self):
+        """A %0d%0a in the selector decodes to raw CRLF -- the parser must
+        fail closed rather than relying solely on a downstream re-check."""
+        with pytest.raises(ValueError, match=r"control character"):
+            parse_gopher_url("gopher://example.com/0sel%0d%0aINJECT")
+
+    def test_percent_encoded_nul_in_selector_is_rejected(self):
+        """A percent-encoded NUL must be rejected at parse time."""
+        with pytest.raises(ValueError, match=r"control character"):
+            parse_gopher_url("gopher://example.com/0sel%00evil")
+
+    def test_percent_encoded_control_char_in_search_is_rejected(self):
+        """A control char in the type-7 search field must be rejected."""
+        with pytest.raises(ValueError, match=r"control character"):
+            parse_gopher_url("gopher://example.com/7sel%09a%0db")


### PR DESCRIPTION
## Summary

A second hardening pass following #44, from a deeper (and adversarially verified) review of the same modules. Each change is self-contained with a regression test written test-first; the set is split into four logical commits.

## Changes

**`feat(security)`: TOFU trust store & durable writes**
- Canonicalize certificate fingerprints (strip `sha256:`/colons, lowercase) on store, compare, and load — a pin pasted in the `openssl`/browser colon-uppercase form now matches the wire digest instead of failing closed against the user's own pin.
- Serialize cross-process store writes with an advisory `flock` and merge with on-disk state, so two server instances can't silently drop each other's pins (deletions thread removed-keys so the merge can't resurrect them).
- `fsync` the temp file and parent dir around the atomic rename so a crash can't truncate the store (which the fail-closed loader would then refuse to start with); the fsync lives inside the cleanup guard so a write failure can't orphan a `.tmp`.
- Add `GEMINI_TOFU_REJECT_EXPIRED` (default off) to fail closed on a certificate outside its validity window; enforce `notBefore` on first use; raise a distinct `TOFUExpiredError`.
- Reject percent-decoded control characters in Gopher selectors/search at parse time; render the mismatch-warning timestamp in UTC; drop the unused `validate_gopher_response`.

**`fix(net)`: bound DNS resolution within the request deadline**
- `validate_target` (which performs `getaddrinfo`) ran outside the timeout envelope in both clients, so a hostname pointing at a tarpit nameserver could stall a worker — and tie up an event-loop executor thread — far past `timeout_seconds`. Resolution is now wrapped in `asyncio.wait_for(timeout_seconds)`.
- Map `TOFUExpiredError` to a distinct `CERTIFICATE_EXPIRED` result (the cert matches the pin but is outside its validity window) instead of the misleading `CERTIFICATE_CHANGED`.

**`fix(ratelimit)`: bound the per-host limiter's memory**
- With throttling enabled the `_next_allowed` map grew one entry per distinct host forever (an open-world fetcher visits unbounded hosts). It now sweeps entries whose reservation has already elapsed once the map exceeds a threshold; the just-reserved host is always in the future, so throttling is unaffected.

**`refactor(server)`: batch contract, error sanitization, singleton**
- Batch fetch over-limit and client-setup failures now return one error per input URL, keeping the response list index-aligned with the request (a single element silently broke callers zipping responses to URLs); the 50-URL cap is documented in the tool docstrings.
- Defensive `FETCH_ERROR` paths return a generic message to the model rather than echoing the raw exception string (which can leak local paths); the batch item handlers now log the detail server-side.
- Drop the duplicate module-level client-manager singleton in favour of the locked `ClientManager` class singleton, and have `cleanup()` reset it.

## Verification
- **628 tests pass** (15 net-new, each written before the fix), **93.85%** coverage.
- `ruff`, `ruff format`, `mypy --strict`, and `bandit` all clean.
- The full diff was put through an adversarial multi-agent review; the one confirmed finding (a temp-file leak on `fsync` failure) and one error-message-accuracy issue (`CERTIFICATE_EXPIRED` vs `CERTIFICATE_CHANGED`) were fixed and are included above.

## New configuration
- `GEMINI_TOFU_REJECT_EXPIRED` — bool, default `false`.
