### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   selector/search at parse time, not only via the client's re-check.
 - Defensive fetch-error paths return a generic message to the model instead of
   echoing the raw internal exception string (full detail is still logged).
+- Report a missing / unobtainable server certificate as a distinct
+  `CERTIFICATE_UNVERIFIED` result rather than the misleading `CERTIFICATE_CHANGED`
+  ("does not match"), since there is no certificate to compare against.
 
 ### Added
 
@@ -44,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `type/*` wildcards).
 - `GEMINI_TOFU_REJECT_EXPIRED` (default off) to fail closed on a Gemini
   certificate outside its validity window.
+- `GOPHER_MAX_CONCURRENT_REQUESTS` / `GEMINI_MAX_CONCURRENT_REQUESTS` (default 0 =
+  unlimited) — an opt-in cap on simultaneous in-flight fetches, a coarse bound on
+  concurrent sockets/memory complementary to the per-host rate limit.
 - LLM-facing text render cap (`GOPHER_/GEMINI_MAX_RENDERED_CHARS`, default 50000)
   with a `truncated` flag, distinct from the network byte cap.
 - Rich tool input schemas (descriptions + examples), `readOnlyHint`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-08
+
 ### Security
 
 - Block CGNAT (`100.64.0.0/10`) and deprecated IPv6 site-local (`fec0::/10`) in
@@ -226,7 +228,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extensive test suite with >90% coverage
 - Complete documentation and examples
 
-[Unreleased]: https://github.com/cameronrye/gopher-mcp/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/cameronrye/gopher-mcp/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/cameronrye/gopher-mcp/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/cameronrye/gopher-mcp/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/cameronrye/gopher-mcp/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/cameronrye/gopher-mcp/compare/v0.1.0...v0.2.1
 [0.1.0]: https://github.com/cameronrye/gopher-mcp/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gopher-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "A cross-platform Model Context Protocol (MCP) server for browsing Gopher and Gemini resources"
 readme = "README.md"
 license = "MIT"

--- a/scripts/validate-release.py
+++ b/scripts/validate-release.py
@@ -200,7 +200,7 @@ class ReleaseValidator:
             "README.md",
             "CHANGELOG.md",
             "docs/migration-guide.md",
-            "docs/release-checklist.md",
+            "docs/RELEASE_CHECKLIST.md",
         ]
 
         missing_docs = []

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.cameronrye/gopher-mcp",
   "description": "MCP server for browsing Gopher and Gemini protocol resources safely, with SSRF protection, TLS/TOFU, and structured JSON output.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "url": "https://github.com/cameronrye/gopher-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registry_type": "pypi",
       "registry_base_url": "https://pypi.org",
       "identifier": "gopher-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/gopher_mcp/config.py
+++ b/src/gopher_mcp/config.py
@@ -78,6 +78,14 @@ class GopherConfig(BaseSettings):
         ge=0,
         le=6000,
     )
+    max_concurrent_requests: int = Field(
+        default=0,
+        description="Cap on simultaneous in-flight fetches (0 = unlimited); a "
+        "coarse bound on concurrent sockets/memory, complementary to the "
+        "per-host rate limit. Off by default.",
+        ge=0,
+        le=1000,
+    )
 
     model_config = SettingsConfigDict(
         env_prefix="GOPHER_",
@@ -176,6 +184,14 @@ class GeminiConfig(BaseSettings):
         "honoured regardless of this setting.",
         ge=0,
         le=6000,
+    )
+    max_concurrent_requests: int = Field(
+        default=0,
+        description="Cap on simultaneous in-flight fetches (0 = unlimited); a "
+        "coarse bound on concurrent sockets/memory, complementary to the "
+        "per-host rate limit. Off by default.",
+        ge=0,
+        le=1000,
     )
     denied_mime_types: list[str] = Field(
         default_factory=list,

--- a/src/gopher_mcp/gemini_client.py
+++ b/src/gopher_mcp/gemini_client.py
@@ -19,7 +19,12 @@ from .models import (
 )
 from .ratelimit import RateLimiter
 from .ssrf import SSRFError, normalize_host, validate_target
-from .tofu import TOFUExpiredError, TOFUManager, TOFUValidationError
+from .tofu import (
+    TOFUExpiredError,
+    TOFUManager,
+    TOFUUnavailableError,
+    TOFUValidationError,
+)
 from .utils import (
     parse_gemini_response,
     parse_gemini_url,
@@ -57,6 +62,7 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         client_certs_storage_path: str | None = None,
         max_rendered_chars: int = DEFAULT_MAX_RENDERED_CHARS,
         requests_per_minute: float = 0.0,
+        max_concurrent_requests: int = 0,
         denied_mime_types: list[str] | None = None,
     ) -> None:
         """Initialize the Gemini client.
@@ -83,6 +89,13 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         self.max_cache_entries = max_cache_entries
         self.max_rendered_chars = max_rendered_chars
         self._rate_limiter = RateLimiter(requests_per_minute)
+        self.max_concurrent_requests = max_concurrent_requests
+        # Opt-in coarse cap on simultaneous fetches (None = unlimited).
+        self._fetch_semaphore = (
+            asyncio.Semaphore(max_concurrent_requests)
+            if max_concurrent_requests > 0
+            else None
+        )
         self.denied_mime_types = frozenset(denied_mime_types or ())
         self.allowed_hosts = set(allowed_hosts) if allowed_hosts else None
         self.allow_local_hosts = allow_local_hosts
@@ -183,8 +196,8 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
                 "timestamp": time.time(),
             }
 
-            # Fetch the content
-            response = await self._fetch_content(parsed_url)
+            # Fetch the content (optionally bounded by the concurrency cap)
+            response = await self._bounded_fetch(parsed_url)
 
             # Honour a server SLOW_DOWN (status 44): back off this host for the
             # advertised number of seconds (meta) regardless of the configured
@@ -233,6 +246,10 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
             # TOFUValidationError handler since it is a subclass). The message
             # names host:port and a category only -- safe to surface.
             return self._error_result(url, "CERTIFICATE_EXPIRED", str(e), e)
+        except TOFUUnavailableError as e:
+            # No certificate to compare against (not a mismatch). Also a subclass,
+            # so it must precede the TOFUValidationError handler.
+            return self._error_result(url, "CERTIFICATE_UNVERIFIED", str(e), e)
         except TOFUValidationError as e:
             return self._error_result(
                 url,
@@ -286,6 +303,13 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         except (TypeError, ValueError):
             seconds = 60.0
         self._rate_limiter.penalize(host, seconds)
+
+    async def _bounded_fetch(self, parsed_url: GeminiURL) -> GeminiFetchResponse:
+        """Run :meth:`_fetch_content`, bounded by the concurrency cap if set."""
+        if self._fetch_semaphore is None:
+            return await self._fetch_content(parsed_url)
+        async with self._fetch_semaphore:
+            return await self._fetch_content(parsed_url)
 
     async def _fetch_content(self, parsed_url: GeminiURL) -> GeminiFetchResponse:
         """Fetch content from parsed Gemini URL using TLS.
@@ -379,8 +403,9 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
                     # The TLS layer runs with CERT_NONE, so TOFU is the only
                     # thing authenticating the peer. Without a fingerprint we
                     # cannot apply the pin -- refuse rather than send the
-                    # request to an unverified server.
-                    raise TOFUValidationError(
+                    # request to an unverified server. This is a distinct failure
+                    # from a fingerprint mismatch (there is nothing to compare).
+                    raise TOFUUnavailableError(
                         "No certificate fingerprint available; cannot verify "
                         "the server identity via TOFU"
                     )

--- a/src/gopher_mcp/gopher_client.py
+++ b/src/gopher_mcp/gopher_client.py
@@ -83,6 +83,7 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
         max_search_length: int = DEFAULT_MAX_SEARCH_LENGTH,
         max_rendered_chars: int = DEFAULT_MAX_RENDERED_CHARS,
         requests_per_minute: float = 0.0,
+        max_concurrent_requests: int = 0,
     ) -> None:
         """Initialize the Gopher client.
 
@@ -95,6 +96,8 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             allowed_hosts: List of allowed hostnames (None = allow all)
             max_selector_length: Maximum selector string length
             max_search_length: Maximum search query length
+            max_concurrent_requests: Cap on simultaneous in-flight fetches
+                (0 = unlimited); a coarse bound on concurrent sockets/memory.
 
         """
         self.max_response_size = max_response_size
@@ -106,6 +109,13 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
         self.max_search_length = max_search_length
         self.max_rendered_chars = max_rendered_chars
         self._rate_limiter = RateLimiter(requests_per_minute)
+        self.max_concurrent_requests = max_concurrent_requests
+        # Opt-in coarse cap on simultaneous fetches (None = unlimited).
+        self._fetch_semaphore = (
+            asyncio.Semaphore(max_concurrent_requests)
+            if max_concurrent_requests > 0
+            else None
+        )
 
         self.allow_local_hosts = allow_local_hosts
 
@@ -204,8 +214,8 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
                 "timestamp": time.time(),
             }
 
-            # Fetch the content
-            response = await self._fetch_content(parsed_url)
+            # Fetch the content (optionally bounded by the concurrency cap)
+            response = await self._bounded_fetch(parsed_url)
             # Merge (not clobber) so any fields a processor attached survive --
             # matches the Gemini client and avoids a latent maintenance trap.
             if hasattr(response, "request_info"):
@@ -261,6 +271,13 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             error={"code": code, "message": message},
             requestInfo={"url": url, "timestamp": time.time()},
         )
+
+    async def _bounded_fetch(self, parsed_url: GopherURL) -> GopherFetchResponse:
+        """Run :meth:`_fetch_content`, bounded by the concurrency cap if set."""
+        if self._fetch_semaphore is None:
+            return await self._fetch_content(parsed_url)
+        async with self._fetch_semaphore:
+            return await self._fetch_content(parsed_url)
 
     async def _fetch_content(self, parsed_url: GopherURL) -> GopherFetchResponse:
         """Fetch content from a parsed Gopher URL over the native transport.

--- a/src/gopher_mcp/server.py
+++ b/src/gopher_mcp/server.py
@@ -137,6 +137,7 @@ class ClientManager:
                     max_search_length=gopher_config.max_search_length,
                     max_rendered_chars=gopher_config.max_rendered_chars,
                     requests_per_minute=gopher_config.requests_per_minute,
+                    max_concurrent_requests=gopher_config.max_concurrent_requests,
                 )
                 logger.info(
                     "Gopher client initialized",
@@ -180,6 +181,7 @@ class ClientManager:
                     client_certs_storage_path=client_certs_path,
                     max_rendered_chars=gemini_config.max_rendered_chars,
                     requests_per_minute=gemini_config.requests_per_minute,
+                    max_concurrent_requests=gemini_config.max_concurrent_requests,
                     denied_mime_types=gemini_config.denied_mime_types,
                 )
                 logger.info(

--- a/src/gopher_mcp/tofu.py
+++ b/src/gopher_mcp/tofu.py
@@ -128,6 +128,16 @@ class TOFUExpiredError(TOFUValidationError):
     """
 
 
+class TOFUUnavailableError(TOFUValidationError):
+    """No usable certificate was available to apply the TOFU pin.
+
+    Distinct from a fingerprint *mismatch*: there is nothing to compare against
+    (the TLS layer yielded no peer certificate fingerprint), so reporting it as
+    "certificate changed / does not match" would be misleading. The connection
+    is still refused (fail closed) -- the peer simply can't be authenticated.
+    """
+
+
 class TOFUManager:
     """Trust-on-First-Use certificate validation manager."""
 

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -175,6 +175,42 @@ class TestGeminiClientFetch:
             mock_parse.assert_called_once_with("gemini://example.com/")
 
     @pytest.mark.asyncio
+    async def test_max_concurrent_requests_bounds_inflight(self):
+        """An opt-in concurrency cap limits simultaneous in-flight fetches."""
+        import asyncio
+
+        from gopher_mcp.models import GeminiMimeType, GeminiSuccessResult
+
+        client = GeminiClient(
+            max_concurrent_requests=2,
+            cache_enabled=False,
+            tofu_enabled=False,
+            client_certs_enabled=False,
+        )
+        inflight = 0
+        peak = 0
+
+        async def fake(_parsed_url):
+            nonlocal inflight, peak
+            inflight += 1
+            peak = max(peak, inflight)
+            await asyncio.sleep(0.02)
+            inflight -= 1
+            return GeminiSuccessResult(
+                content="hi",
+                mimeType=GeminiMimeType(type="text", subtype="plain"),
+                size=2,
+                requestInfo={},
+            )
+
+        client._fetch_content = fake  # type: ignore[method-assign]
+        await asyncio.gather(
+            *[client.fetch(f"gemini://example.org/{i}") for i in range(6)]
+        )
+        assert peak == 2
+        await client.close()
+
+    @pytest.mark.asyncio
     async def test_dns_resolution_is_bounded_by_request_timeout(self):
         """A hanging resolver must not exceed the request deadline. DNS was
         previously outside the timeout envelope, so a tarpit nameserver could
@@ -220,7 +256,10 @@ class TestGeminiClientFetch:
         result = await client.fetch("gemini://example.com/")
 
         assert isinstance(result, GeminiErrorResult)
-        assert result.error["code"] == "CERTIFICATE_CHANGED"
+        # Distinct from a fingerprint mismatch: there is no cert to compare, so
+        # reporting CERTIFICATE_CHANGED ("does not match") would be misleading.
+        assert result.error["code"] == "CERTIFICATE_UNVERIFIED"
+        assert "does not match" not in result.error["message"].lower()
         client.tls_client.send_data.assert_not_awaited()  # never reached the wire
 
     @pytest.mark.asyncio

--- a/tests/test_gopher_client.py
+++ b/tests/test_gopher_client.py
@@ -818,6 +818,58 @@ class TestFetchContentMethod:
             await client._fetch_content(parsed_url)
 
     @pytest.mark.asyncio
+    async def test_max_concurrent_requests_bounds_inflight(self):
+        """An opt-in concurrency cap limits simultaneous in-flight fetches."""
+        import asyncio
+
+        from gopher_mcp.models import TextResult
+
+        client = GopherClient(max_concurrent_requests=2, cache_enabled=False)
+        inflight = 0
+        peak = 0
+
+        async def fake(_parsed_url):
+            nonlocal inflight, peak
+            inflight += 1
+            peak = max(peak, inflight)
+            await asyncio.sleep(0.02)
+            inflight -= 1
+            return TextResult(bytes=2, text="hi")
+
+        client._fetch_content = fake  # type: ignore[method-assign]
+        await asyncio.gather(
+            *[client.fetch(f"gopher://example.com/0/{i}") for i in range(6)]
+        )
+        assert peak == 2  # cap saturated but never exceeded
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_unlimited_concurrency_by_default(self):
+        """The cap is opt-in: default (0) leaves concurrency unbounded."""
+        import asyncio
+
+        from gopher_mcp.models import TextResult
+
+        client = GopherClient(cache_enabled=False)  # default: no cap
+        inflight = 0
+        peak = 0
+
+        async def fake(_parsed_url):
+            nonlocal inflight, peak
+            inflight += 1
+            peak = max(peak, inflight)
+            await asyncio.sleep(0.02)
+            inflight -= 1
+            return TextResult(bytes=2, text="hi")
+
+        client._fetch_content = fake  # type: ignore[method-assign]
+        await asyncio.gather(
+            *[client.fetch(f"gopher://example.com/0/{i}") for i in range(6)]
+        )
+        assert peak == 6  # all ran concurrently
+        await client.close()
+
+    @pytest.mark.asyncio
     async def test_dns_resolution_is_bounded_by_request_timeout(self):
         """A hanging resolver must not exceed the request deadline. DNS was
         previously outside the timeout envelope, so a tarpit nameserver could

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,6 +1,6 @@
 """Security and penetration tests for Gopher and Gemini protocols."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -135,26 +135,36 @@ class TestResourceExhaustion:
 
     @pytest.mark.asyncio
     async def test_timeout_protection(self):
-        """Test timeout protection against slow responses."""
-        client = GeminiClient(timeout_seconds=1)  # 1 second timeout
+        """A response slower than the deadline is bounded, not awaited forever.
 
-        # Mock a slow connection
-        async def slow_connect(*args, **kwargs):
-            import asyncio
+        TOFU is disabled here so the request reaches the read phase; the slow
+        ``receive_data`` is wrapped in the client's overall ``wait_for`` deadline,
+        which must fire and surface a timeout error rather than hang.
+        """
+        import asyncio
 
-            await asyncio.sleep(2)  # Longer than timeout
-            return Mock(), {}
+        client = GeminiClient(
+            timeout_seconds=0.1,
+            tofu_enabled=False,
+            client_certs_enabled=False,
+        )
 
-        with patch.object(client.tls_client, "connect", side_effect=slow_connect):
-            result = await client.fetch("gemini://example.com/")
+        async def slow_receive(*args, **kwargs):
+            await asyncio.sleep(2)  # far longer than the 0.1s deadline
+            return b"20 text/gemini\r\nhi"
 
-            # Should return timeout error
-            assert isinstance(result, GeminiErrorResult)
-            # Check for TLS connection error instead of timeout
-            assert (
-                "tls" in result.error["message"].lower()
-                or "failed" in result.error["message"].lower()
-            )
+        client.tls_client.connect = AsyncMock(  # type: ignore[method-assign]
+            return_value=(Mock(), {"cert_fingerprint": "x"})
+        )
+        client.tls_client.send_data = AsyncMock()  # type: ignore[method-assign]
+        client.tls_client.receive_data = slow_receive  # type: ignore[method-assign]
+        client.tls_client.close = AsyncMock()  # type: ignore[method-assign]
+
+        result = await client.fetch("gemini://example.com/")
+
+        assert isinstance(result, GeminiErrorResult)
+        assert result.error["code"] == "FETCH_ERROR"
+        assert "timed out" in result.error["message"].lower()
 
     def test_memory_exhaustion_protection(self):
         """Test protection against memory exhaustion."""


### PR DESCRIPTION
## Release 0.4.0

Cuts the **0.4.0** release (from 0.3.0) and includes two final follow-up hardening fixes from the deeper review. Local release gate (`scripts/validate-release.py`) is **13/13 — RELEASE READY**.

> Tag `v0.4.0` after merge to publish to PyPI — I've intentionally **not** tagged.

### Follow-up fixes included in this release
- **`CERTIFICATE_UNVERIFIED`** — when the TLS layer yields no usable server certificate (no fingerprint to pin), the client now fails closed with a distinct `CERTIFICATE_UNVERIFIED` result instead of the misleading `CERTIFICATE_CHANGED` ("does not match") — there is nothing to compare against. New `TOFUUnavailableError`.
- **Opt-in concurrency cap** — `GOPHER_MAX_CONCURRENT_REQUESTS` / `GEMINI_MAX_CONCURRENT_REQUESTS` (default `0` = unlimited) bound simultaneous in-flight fetches via a per-client semaphore, complementing the per-host rate limit. The MCP batch tools already cap internal concurrency at 5; this also bounds the public client API and concurrent single-fetch tool calls.
- Rewrote `test_timeout_protection` to genuinely exercise the read deadline (a slow `receive_data` under a short timeout) rather than coincidentally matching a substring of the old TOFU error message.

> The TLS cipher allowlist (the third deferred item) was evaluated and **deliberately left as-is**: it's a strong, broadly-compatible TLS 1.2 set (ECDHE + AEAD — GCM and ChaCha20, both ECDSA/RSA). Relaxing it to CBC/non-PFS suites for rare legacy servers would weaken the posture under an already-`CERT_NONE` model.

### 0.4.0 highlights (the full accumulated `[Unreleased]` → `[0.4.0]`)
This release rolls up everything merged since 0.3.0 — see `CHANGELOG.md` for the complete list. Notable items:
- **Security:** bound DNS resolution within the request deadline; TOFU fingerprint canonicalization, cross-process store locking + merge, and durable (`fsync`) writes; `GEMINI_TOFU_REJECT_EXPIRED` (fail closed on out-of-window certs, distinct `CERTIFICATE_EXPIRED`); Gopher control-char parse hardening; generic defensive error messages.
- **Added:** per-host rate limiting, MIME content filter, LLM-facing render cap, `gemini_fetch` input arg, the two new config knobs above.
- **Changed/Fixed:** batch tools keep responses index-aligned with requests; rate-limiter memory bounded; client-manager singleton collapsed; gemtext/RFC parsing fixes.

### Release mechanics
- Version bumped to `0.4.0` in `pyproject.toml` and `server.json` (both occurrences); `__version__` derives from package metadata.
- `CHANGELOG.md` `[Unreleased]` rolled into `[0.4.0] - 2026-06-08`; added the previously-missing `0.3.0` link reference.
- Fixed a stale path in `validate-release.py` (`docs/release-checklist.md` → `docs/RELEASE_CHECKLIST.md`) so the gate reports accurately.

### Verification
- `validate-release.py`: 13/13 (lint, format, mypy, bandit, pip-audit, tests, coverage, build, docs build, functionality).
- 631 tests pass, 93.94% coverage.
