### PR TITLE
chore: remove Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,17 +49,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests
-        run: uv run pytest --cov-report=xml
-
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage.xml
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests
-          name: codecov-umbrella
+        run: uv run pytest
 
   gemini-tests:
     name: Gemini Protocol Tests

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![PyPI version](https://badge.fury.io/py/gopher-mcp.svg)](https://badge.fury.io/py/gopher-mcp)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![codecov](https://codecov.io/gh/cameronrye/gopher-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/cameronrye/gopher-mcp)
 [![Code style: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![Downloads](https://pepy.tech/badge/gopher-mcp)](https://pepy.tech/project/gopher-mcp)

--- a/docs/development/repository-setup.md
+++ b/docs/development/repository-setup.md
@@ -132,7 +132,7 @@ updates:
 ## Secrets and Variables
 
 ### Repository Secrets
-- `CODECOV_TOKEN`: For code coverage reporting (if using Codecov)
+None required.
 
 ### Environment Secrets
 No secrets needed for OIDC-based PyPI publishing.
@@ -182,9 +182,8 @@ mkdocs.yml @cameronrye
 ## Automation Setup
 
 ### Required GitHub Apps/Integrations
-1. **Codecov** (optional): For code coverage reporting
-2. **Dependabot**: Already built into GitHub
-3. **GitHub Actions**: Built-in CI/CD
+1. **Dependabot**: Already built into GitHub
+2. **GitHub Actions**: Built-in CI/CD
 
 ### PyPI Trusted Publishing Setup
 


### PR DESCRIPTION
Removes the Codecov integration, which is no longer used:

- **README**: drop the `codecov` coverage badge.
- **CI** (`.github/workflows/ci.yml`): remove the "Upload coverage to Codecov" step and the now-orphaned `--cov-report=xml` flag on the test command (pyproject's `addopts` still generates coverage reports for local use).
- **Docs** (`docs/development/repository-setup.md`): drop the `CODECOV_TOKEN` secret entry and the Codecov integration item.

No functional change to the test suite or coverage gate (`--cov-fail-under=85` stays in pyproject). The `CODECOV_TOKEN` repo secret can now be deleted in GitHub settings if present.