### PR TITLE
chore: sync uv.lock to 0.4.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -752,7 +752,7 @@ wheels = [
 
 [[package]]
 name = "gopher-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Post-0.4.0 housekeeping. The release PR (#46) bumped `pyproject.toml` and `server.json` to 0.4.0 but didn't refresh the lockfile, so `uv.lock` still pins the editable `gopher-mcp` package at 0.3.0. Re-resolved with `uv lock` — the only change is that one version line (0.3.0 → 0.4.0), matching the project's established "sync uv.lock" step from prior releases.