### PR TITLE
docs: auto-generate model reference, lint docs/, add changelog entry

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,8 @@
 {
-  "MD013": {
-    "line_length": 128
-  },
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD029": { "style": "ordered" },
   "MD033": false,
-  "MD036": false
+  "MD036": false,
+  "MD040": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,7 @@ repos:
     hooks:
       - id: markdownlint
         args: [--fix]
-        exclude: ^(CHANGELOG.md|docs/|wiki-content/)
+        exclude: ^(CHANGELOG.md|wiki-content/)
 
   # YAML formatting
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made the published documentation site the single source of truth: consolidated
+  six overlapping release/PyPI/testing docs into one `development/releasing`
+  guide, surfaced the previously-orphaned Configuration and Architecture pages in
+  the nav, added a general Troubleshooting page, and corrected the docs against
+  the v0.4.0 source — all four MCP tools (plus the `gemini_fetch` `input`
+  parameter and the batch-fetch tools) and PyPI install are now documented,
+  server/logging environment variables carry the `GOPHER_MCP_` prefix, TOFU and
+  certificate paths point to `~/.gemini`, and the Gemini specification is
+  standardized to v0.24.1.
+- Added an auto-generated Data Models reference page (via mkdocstrings) rendered
+  directly from the Pydantic models, replacing the hand-written response-type
+  interfaces in the API reference so they can no longer drift from the code.
+- Enabled markdownlint on the `docs/` tree in pre-commit/CI.
+
+### Removed
+
+- Deleted the duplicate `wiki-content/` documentation tree (its unique
+  general/Claude Desktop troubleshooting and per-OS config paths were migrated
+  into `docs/`) and dropped the internal Gemini planning drafts (project
+  timeline, API contracts, security architecture) from the public site.
+
+### Fixed
+
+- Removed fabricated `GEMINI_TLS_*`, `DEBUG_COMPONENTS`, and `MCP_SERVER_*`
+  environment variables and stale single-tool / source-only / Pituophis /
+  `tools.py` / `GopherMCPServer` claims from the documentation, and corrected the
+  documented response-model fields to match the code.
+
 ## [0.4.0] - 2026-06-08
 
 ### Security

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -24,6 +24,7 @@ client = GopherClient(
 ```
 
 Environment variable configuration:
+
 ```bash
 export GOPHER_ALLOWED_HOSTS="gopher.floodgap.com,gopher.quux.org"
 ```
@@ -56,6 +57,7 @@ client = GopherClient(
 ```
 
 Environment variables:
+
 ```bash
 export GOPHER_CACHE_ENABLED=true
 export GOPHER_CACHE_TTL_SECONDS=300
@@ -101,6 +103,7 @@ gopher-mcp --transport sse
 ### HTTP API
 
 The HTTP transports provide a JSON-RPC 2.0 API. Example request:
+
 ```json
 {
   "jsonrpc": "2.0",
@@ -151,11 +154,13 @@ Full support for Gopher search servers (type 7):
 ### URL Formats
 
 Standard query parameter:
+
 ```
 gopher://veronica.example.com/7/search?python
 ```
 
 Tab-encoded format:
+
 ```
 gopher://veronica.example.com/7/search%09python
 ```
@@ -224,6 +229,7 @@ GEMINI_TOFU_STORAGE_PATH=/custom/path/tofu.json
 ```
 
 **TOFU Workflow:**
+
 - First connection stores certificate fingerprint
 - Subsequent connections verify against stored fingerprint
 - Certificate changes trigger validation errors
@@ -242,6 +248,7 @@ GEMINI_CLIENT_CERTS_STORAGE_PATH=/custom/path/certs/
 ```
 
 **Features:**
+
 - Automatic certificate generation per hostname/path scope
 - Secure private key storage with owner-only (700/600) permissions
 - Certificate reuse within the same scope
@@ -269,6 +276,7 @@ GEMINI_MAX_CACHE_ENTRIES=2000
 ```
 
 **Cache Features:**
+
 - Protocol-isolated caching (separate from Gopher cache)
 - TTL-based expiration
 - LRU eviction when cache is full
@@ -286,11 +294,13 @@ GEMINI_ALLOWED_HOSTS=geminiprotocol.net,warmedal.se,kennedy.gemi.dev
 ## Security Best Practices
 
 ### Gopher Protocol
+
 1. **Use Host Allowlists**: Restrict access to trusted Gopher servers
 2. **Set Reasonable Limits**: Configure appropriate size and timeout limits
 3. **Monitor Logs**: Use structured logging for security monitoring
 
 ### Gemini Protocol
+
 1. **Enable TOFU**: Always use TOFU certificate validation in production; TLS 1.2+ is enforced automatically
 2. **Fail Closed on Bad Certificates**: Set `GEMINI_TOFU_REJECT_EXPIRED=true` to reject certificates outside their validity window
 3. **Client Certificates**: Enable automatic client certificate management for authenticated access
@@ -298,6 +308,7 @@ GEMINI_ALLOWED_HOSTS=geminiprotocol.net,warmedal.se,kennedy.gemi.dev
 5. **Certificate Monitoring**: Monitor certificate validation failures
 
 ### General
+
 1. **Regular Updates**: Keep dependencies updated for security patches
 2. **Network Isolation**: Consider running in isolated network environments
 3. **Structured Logging**: Use structured logging for security monitoring

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -170,7 +170,9 @@ Regular paragraph text.
 > Quoted text
 
 ```
+
 Preformatted text block
+
 ```
 
 => gemini://example.org/ Link with text

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,9 @@
 
 This document provides a comprehensive reference for the Gopher & Gemini MCP Server API.
 
+For the exhaustive, always-in-sync field definitions of every result type, see
+the auto-generated [Data Models](reference/models.md) page.
+
 ## MCP Tools
 
 The server provides four tools: `gopher_fetch` and `gemini_fetch` for single
@@ -86,72 +89,19 @@ if result["kind"] == "error":
 
 #### Response Types
 
-##### MenuResult
+`gopher_fetch` returns one of these result objects, distinguished by the `kind`
+field. See [Data Models](reference/models.md) for the complete, always-in-sync
+field definitions generated from the source.
 
-Returned for Gopher menus (type 1) and search results (type 7).
+| `kind` | Type | Returned for |
+|--------|------|--------------|
+| `menu` | [`MenuResult`][gopher_mcp.models.MenuResult] | Gopher menus (type 1) and search results (type 7); the `items` are [`GopherMenuItem`][gopher_mcp.models.GopherMenuItem] entries |
+| `text` | [`TextResult`][gopher_mcp.models.TextResult] | Text files (type 0) |
+| `binary` | [`BinaryResult`][gopher_mcp.models.BinaryResult] | Binary item types (4, 5, 6, 9, g, I) — metadata only |
+| `error` | [`ErrorResult`][gopher_mcp.models.ErrorResult] | Errors and unsupported content |
 
-```typescript
-interface MenuResult {
-  kind: "menu";
-  items: MenuItem[];
-  server_info: ServerInfo;
-  request_info: RequestInfo;
-}
-
-interface MenuItem {
-  type: string;           // Gopher item type (0, 1, 7, etc.)
-  display_text: string;   // Human-readable text
-  selector: string;       // Gopher selector
-  host: string;          // Server hostname
-  port: number;          // Server port
-  url?: string;          // Full URL if constructible
-}
-```
-
-##### TextResult
-
-Returned for text files (type 0).
-
-```typescript
-interface TextResult {
-  kind: "text";
-  content: string;        // Text content
-  encoding: string;       // Character encoding
-  size: number;          // Content size in bytes
-  server_info: ServerInfo;
-  request_info: RequestInfo;
-}
-```
-
-##### BinaryResult
-
-Returned for binary files (types 4, 5, 6, 9, g, I). Contains metadata only.
-
-```typescript
-interface BinaryResult {
-  kind: "binary";
-  item_type: string;      // Gopher item type
-  description: string;    // File description
-  size?: number;         // File size if available
-  server_info: ServerInfo;
-  request_info: RequestInfo;
-}
-```
-
-##### ErrorResult
-
-Returned for errors or unsupported content.
-
-```typescript
-interface ErrorResult {
-  kind: "error";
-  error: string;          // Error message
-  details?: string;       // Additional details
-  suggestions?: string[]; // Troubleshooting suggestions
-  server_info?: ServerInfo;
-  request_info: RequestInfo;
-}
-```
+Every result also carries a `request_info` object (request URL, host, port, and
+timing metadata).
 
 ### `gemini_fetch`
 
@@ -271,126 +221,17 @@ if result["kind"] == "gemtext":
 
 #### Response Types
 
-##### GeminiGemtextResult
+`gemini_fetch` returns one of these result objects, distinguished by the `kind`
+field. See [Data Models](reference/models.md) for the complete field definitions.
 
-Returned for gemtext content (text/gemini MIME type).
-
-```typescript
-interface GeminiGemtextResult {
-  kind: "gemtext";
-  document: GemtextDocument;
-  raw_content: string;    // Original gemtext source
-  charset: string;        // Character encoding
-  size: number;          // Content size in bytes
-  request_info: RequestInfo;
-}
-
-interface GemtextDocument {
-  lines: GemtextLine[];
-  links: GemtextLink[];
-  headings: GemtextHeading[];
-}
-
-interface GemtextLine {
-  type: "text" | "link" | "heading1" | "heading2" | "heading3" |
-        "list_item" | "quote" | "preformat_toggle" | "preformat";
-  text: string;
-  url?: string;           // For link lines
-  alt_text?: string;      // For preformat blocks
-}
-
-interface GemtextLink {
-  url: string;
-  text?: string;          // Link text (optional)
-  line_number: number;    // Line number in document
-}
-
-interface GemtextHeading {
-  level: 1 | 2 | 3;      // Heading level
-  text: string;          // Heading text
-  line_number: number;   // Line number in document
-}
-```
-
-##### GeminiSuccessResult
-
-Returned for non-gemtext content (text, binary, etc.).
-
-```typescript
-interface GeminiSuccessResult {
-  kind: "success";
-  mime_type: GeminiMimeType;
-  content: string | bytes; // Text content or binary data
-  size: number;           // Content size in bytes
-  request_info: RequestInfo;
-}
-
-interface GeminiMimeType {
-  full_type: string;      // Complete MIME type
-  main_type: string;      // Main type (text, image, etc.)
-  sub_type: string;       // Sub type (plain, html, etc.)
-  charset?: string;       // Character encoding
-  language?: string;      // Content language
-  is_text: boolean;       // Whether content is text
-  is_gemtext: boolean;    // Whether content is gemtext
-  is_binary: boolean;     // Whether content is binary
-}
-```
-
-##### GeminiInputResult
-
-Returned for input requests (status codes 10-11).
-
-```typescript
-interface GeminiInputResult {
-  kind: "input";
-  prompt: string;         // Input prompt text
-  sensitive: boolean;     // Whether input is sensitive (password)
-  request_info: RequestInfo;
-}
-```
-
-##### GeminiRedirectResult
-
-Returned for redirects (status codes 30-31).
-
-```typescript
-interface GeminiRedirectResult {
-  kind: "redirect";
-  url: string;           // New URL to redirect to
-  permanent: boolean;    // Whether redirect is permanent
-  request_info: RequestInfo;
-}
-```
-
-##### GeminiErrorResult
-
-Returned for errors (status codes 40-69).
-
-```typescript
-interface GeminiErrorResult {
-  kind: "error";
-  status: number;        // Gemini status code
-  message: string;       // Error message
-  is_temporary: boolean; // Whether error is temporary
-  is_server_error: boolean; // Whether error is server-side
-  is_client_error: boolean; // Whether error is client-side
-  request_info: RequestInfo;
-}
-```
-
-##### GeminiCertificateResult
-
-Returned for certificate requests (status codes 60-69).
-
-```typescript
-interface GeminiCertificateResult {
-  kind: "certificate";
-  status: number;        // Gemini status code
-  message: string;       // Certificate requirement message
-  request_info: RequestInfo;
-}
-```
+| `kind` | Type | Returned for |
+|--------|------|--------------|
+| `gemtext` | [`GeminiGemtextResult`][gopher_mcp.models.GeminiGemtextResult] | `text/gemini` content, parsed into a [`GemtextDocument`][gopher_mcp.models.GemtextDocument] of [`GemtextLine`][gopher_mcp.models.GemtextLine] items |
+| `success` | [`GeminiSuccessResult`][gopher_mcp.models.GeminiSuccessResult] | Other success responses (status 20-29); the MIME type is a [`GeminiMimeType`][gopher_mcp.models.GeminiMimeType] |
+| `input` | [`GeminiInputResult`][gopher_mcp.models.GeminiInputResult] | Input prompts (status 10-11) — answer with the `gemini_fetch` `input` parameter |
+| `redirect` | [`GeminiRedirectResult`][gopher_mcp.models.GeminiRedirectResult] | Redirects (status 30-31) |
+| `error` | [`GeminiErrorResult`][gopher_mcp.models.GeminiErrorResult] | Errors (status 40-59) |
+| `certificate` | [`GeminiCertificateResult`][gopher_mcp.models.GeminiCertificateResult] | Client-certificate requests (status 60-69) |
 
 ### `gopher_batch_fetch`
 
@@ -448,30 +289,12 @@ for result in results:
 
 ## Common Types
 
-### ServerInfo
+### `request_info`
 
-Information about the Gopher server.
-
-```typescript
-interface ServerInfo {
-  host: string;          // Server hostname
-  port: number;          // Server port
-  protocol: "gopher";    // Protocol name
-}
-```
-
-### RequestInfo
-
-Information about the request.
-
-```typescript
-interface RequestInfo {
-  url: string;           // Original request URL
-  timestamp: number;     // Unix timestamp
-  protocol: "gopher" | "gemini"; // Protocol used
-  cached?: boolean;      // Whether response was cached
-}
-```
+Every result includes a `request_info` field — a free-form object
+(`dict[str, Any]`) carrying metadata about the request, such as the requested
+URL, host, port, and timing. It is not a fixed schema, so treat its keys as
+best-effort metadata rather than a guaranteed contract.
 
 ## Status Codes
 
@@ -559,6 +382,7 @@ Common Gopher errors and how to handle them:
 **Cause**: Server is unreachable or slow to respond
 
 **Solution**:
+
 ```python
 # Increase timeout in configuration
 # GOPHER_TIMEOUT_SECONDS=60
@@ -575,6 +399,7 @@ if result["kind"] == "error" and "timeout" in result["error"].lower():
 **Cause**: Malformed URL structure
 
 **Solution**:
+
 ```python
 # Ensure URL follows gopher://host[:port]/type/selector format
 valid_url = "gopher://gopher.floodgap.com/1/"
@@ -590,6 +415,7 @@ result = await gopher_fetch(valid_url)
 **Cause**: Server returned unknown or unsupported item type
 
 **Solution**:
+
 ```python
 result = await gopher_fetch("gopher://example.com/X/unknown")
 if result["kind"] == "error" and "unsupported" in result["error"].lower():
@@ -605,6 +431,7 @@ if result["kind"] == "error" and "unsupported" in result["error"].lower():
 **Cause**: Response size exceeds configured maximum
 
 **Solution**:
+
 ```python
 # Increase size limit in configuration
 # GOPHER_MAX_RESPONSE_SIZE=2097152
@@ -625,6 +452,7 @@ Common Gemini errors and how to handle them:
 **Cause**: Certificate or TLS configuration issues
 
 **Solution**:
+
 ```python
 result = await gemini_fetch("gemini://tls-error.example.com/")
 if result["kind"] == "error" and "tls" in result["error"]["message"].lower():
@@ -639,6 +467,7 @@ if result["kind"] == "error" and "tls" in result["error"]["message"].lower():
 **Cause**: Server certificate changed since first visit
 
 **Solution**:
+
 ```python
 # Certificate changed - manual intervention required
 # 1. Verify the change is legitimate
@@ -659,6 +488,7 @@ if result["kind"] == "error" and "tofu" in result["error"]["message"].lower():
 **Cause**: Server returned malformed or invalid status code
 
 **Solution**:
+
 ```python
 result = await gemini_fetch("gemini://broken-server.example.com/")
 if result["kind"] == "error" and "status" in result["error"]["message"].lower():
@@ -672,6 +502,7 @@ if result["kind"] == "error" and "status" in result["error"]["message"].lower():
 **Cause**: Response size exceeds configured maximum
 
 **Solution**:
+
 ```python
 # Increase size limit in configuration
 # GEMINI_MAX_RESPONSE_SIZE=2097152
@@ -688,6 +519,7 @@ if result["kind"] == "error" and "size" in result["error"]["message"].lower():
 **Cause**: Server not in configured allowlist
 
 **Solution**:
+
 ```python
 # Add host to allowlist in configuration
 # GEMINI_ALLOWED_HOSTS=geminiprotocol.net,example.com

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,12 +71,14 @@ The Gopher & Gemini MCP Server is a Model Context Protocol (MCP) server that ena
 **Responsibility**: Expose Gopher and Gemini functionality as MCP tools
 
 **Key Functions**:
+
 - `gopher_fetch(url: str)` - MCP tool for Gopher protocol
 - `gemini_fetch(url: str)` - MCP tool for Gemini protocol
 - Environment variable parsing and validation
 - Client manager singleton access
 
 **Dependencies**:
+
 - FastMCP framework
 - GopherClient
 - GeminiClient
@@ -87,12 +89,14 @@ The Gopher & Gemini MCP Server is a Model Context Protocol (MCP) server that ena
 **Responsibility**: Singleton pattern for client lifecycle management
 
 **Key Features**:
+
 - Single instance per protocol client
 - Lazy initialization
 - Configuration from environment variables
 - Thread-safe access
 
 **Pattern**:
+
 ```python
 class ClientManager:
     _instance = None
@@ -111,6 +115,7 @@ class ClientManager:
 **Responsibility**: Gopher protocol implementation and response processing
 
 **Key Methods**:
+
 - `fetch(url)` - Main entry point
 - `_fetch_content(url)` - Network communication
 - `_process_menu_response()` - Parse Gopher menus
@@ -120,6 +125,7 @@ class ClientManager:
 - `_cache_response()` - Cache storage
 
 **Data Flow**:
+
 ```
 URL → Parse → Check Cache → Fetch (if needed) → Process → Cache → Return
 ```
@@ -129,6 +135,7 @@ URL → Parse → Check Cache → Fetch (if needed) → Process → Cache → Re
 **Responsibility**: Gemini protocol implementation with TLS security
 
 **Key Methods**:
+
 - `fetch(url)` - Main entry point
 - `_fetch_content(url)` - TLS connection and response handling
 - Response parsing by status code (20, 30, 40, 60, etc.)
@@ -136,6 +143,7 @@ URL → Parse → Check Cache → Fetch (if needed) → Process → Cache → Re
 - `_cache_response()` - Cache storage
 
 **Dependencies**:
+
 - GeminiTLSClient
 - TOFUManager
 - ClientCertificateManager
@@ -145,12 +153,14 @@ URL → Parse → Check Cache → Fetch (if needed) → Process → Cache → Re
 **Responsibility**: Low-level TLS connection management
 
 **Key Methods**:
+
 - `connect(host, port)` - Establish TLS connection
 - `send_data(data)` - Send request
 - `receive_data()` - Receive response
 - `close()` - Close connection
 
 **Security Features**:
+
 - TLS 1.2+ enforcement
 - Certificate validation
 - Cipher suite selection
@@ -161,12 +171,14 @@ URL → Parse → Check Cache → Fetch (if needed) → Process → Cache → Re
 **Responsibility**: Trust-on-First-Use certificate validation
 
 **Key Methods**:
+
 - `validate_certificate(host, cert)` - Validate against stored fingerprint
 - `store_certificate(host, cert)` - Store new certificate
 - `load_certificates()` - Load from storage
 - `save_certificates()` - Persist to storage
 
 **Storage Format** (`~/.gemini/tofu.json`):
+
 ```json
 {
   "example.com": {
@@ -182,12 +194,14 @@ URL → Parse → Check Cache → Fetch (if needed) → Process → Cache → Re
 **Responsibility**: Automatic client certificate generation and management
 
 **Key Methods**:
+
 - `get_certificate(host)` - Get or generate certificate for host
 - `generate_certificate(host)` - Generate new certificate
 - `load_certificates()` - Load from storage
 - `save_certificate(host, cert, key)` - Persist certificate
 
 **Storage Structure** (`~/.gemini/client_certs/`):
+
 ```
 ~/.gemini/client_certs/
 ├── example.com.crt
@@ -286,6 +300,7 @@ Request → Hash URL → Check Cache
 **Cache Key**: `SHA256(protocol + url)`
 
 **Cache Entry**:
+
 ```python
 {
     "response": {...},      # Formatted response
@@ -301,12 +316,14 @@ Request → Hash URL → Check Cache
 ### Gopher Security
 
 **Threat Model**:
+
 - No encryption (plaintext protocol)
 - No authentication
 - Potential for malicious content
 - Network eavesdropping
 
 **Mitigations**:
+
 1. **Input Validation**
    - URL format validation
    - Selector sanitization
@@ -329,12 +346,14 @@ Request → Hash URL → Check Cache
 ### Gemini Security
 
 **Threat Model**:
+
 - Man-in-the-middle attacks
 - Certificate spoofing
 - Malicious content
 - Privacy concerns
 
 **Mitigations**:
+
 1. **Transport Security**
    - Mandatory TLS 1.2+
    - Strong cipher suites only
@@ -467,16 +486,19 @@ Return to MCP Client
 ### Caching Strategy
 
 **Benefits**:
+
 - Reduces network requests
 - Improves response time
 - Reduces server load
 
 **Configuration**:
+
 - `GOPHER_CACHE_ENABLED` / `GEMINI_CACHE_ENABLED`
 - `GOPHER_CACHE_TTL_SECONDS` / `GEMINI_CACHE_TTL_SECONDS`
 - `GOPHER_MAX_CACHE_ENTRIES` / `GEMINI_MAX_CACHE_ENTRIES`
 
 **Trade-offs**:
+
 - Memory usage vs. performance
 - Freshness vs. speed
 - Cache size vs. hit rate
@@ -484,11 +506,13 @@ Return to MCP Client
 ### Concurrency Model
 
 **Gopher**:
+
 - Synchronous requests executed in thread pool
 - `asyncio.get_event_loop().run_in_executor()`
 - Non-blocking for async MCP server
 
 **Gemini**:
+
 - Asynchronous TLS connections
 - Native async/await support
 - Efficient connection handling
@@ -496,10 +520,12 @@ Return to MCP Client
 ### Resource Management
 
 **Connection Pooling**:
+
 - Gemini: Connections closed after each request
 - Gopher: Native asyncio transport opens and closes a connection per request
 
 **Memory Management**:
+
 - Response size limits prevent memory exhaustion
 - Cache eviction prevents unbounded growth
 - Streaming not supported (responses buffered)
@@ -610,6 +636,7 @@ Return to MCP Client
 **Framework**: structlog
 
 **Log Levels**:
+
 - `DEBUG`: Detailed diagnostic information
 - `INFO`: General informational messages
 - `WARNING`: Warning messages
@@ -617,6 +644,7 @@ Return to MCP Client
 - `CRITICAL`: Critical failures
 
 **Log Fields**:
+
 ```python
 {
     "event": "gopher_fetch_successful",
@@ -631,6 +659,7 @@ Return to MCP Client
 ### Metrics
 
 **Key Metrics**:
+
 - Request count (per protocol)
 - Response time (per protocol)
 - Cache hit rate

--- a/docs/development/repository-setup.md
+++ b/docs/development/repository-setup.md
@@ -9,6 +9,7 @@ This document outlines the recommended repository settings and branch protection
 Configure the following settings for the `main` branch:
 
 #### Required Status Checks
+
 - ✅ Require status checks to pass before merging
 - ✅ Require branches to be up to date before merging
 - Required checks:
@@ -20,12 +21,14 @@ Configure the following settings for the `main` branch:
   - `docs` (Build documentation)
 
 #### Pull Request Requirements
+
 - ✅ Require a pull request before merging
 - ✅ Require approvals: **1**
 - ✅ Dismiss stale PR approvals when new commits are pushed
 - ✅ Require review from code owners (when CODEOWNERS file is present)
 
 #### Additional Restrictions
+
 - ✅ Restrict pushes that create files larger than 100 MB
 - ✅ Include administrators (recommended for consistency)
 - ✅ Allow force pushes: **Disabled**
@@ -36,6 +39,7 @@ Configure the following settings for the `main` branch:
 ### General Settings
 
 #### Features
+
 - ✅ Wikis: **Enabled** (for community documentation)
 - ✅ Issues: **Enabled**
 - ✅ Sponsorships: **Enabled** (if applicable)
@@ -43,6 +47,7 @@ Configure the following settings for the `main` branch:
 - ✅ Discussions: **Enabled** (for community Q&A)
 
 #### Pull Requests
+
 - ✅ Allow merge commits: **Enabled**
 - ✅ Allow squash merging: **Enabled** (default)
 - ✅ Allow rebase merging: **Enabled**
@@ -53,6 +58,7 @@ Configure the following settings for the `main` branch:
 ### Security Settings
 
 #### Security & Analysis
+
 - ✅ Dependency graph: **Enabled**
 - ✅ Dependabot alerts: **Enabled**
 - ✅ Dependabot security updates: **Enabled**
@@ -97,10 +103,12 @@ updates:
 ### Access & Permissions
 
 #### Collaborators and Teams
+
 - Repository owner: **cameronrye** (Admin)
 - Consider adding trusted maintainers with **Maintain** permissions
 
 #### Actions Permissions
+
 - ✅ Allow all actions and reusable workflows
 - ✅ Allow actions created by GitHub: **Enabled**
 - ✅ Allow actions by Marketplace verified creators: **Enabled**
@@ -109,6 +117,7 @@ updates:
 ### Pages Settings
 
 #### GitHub Pages
+
 - ✅ Source: **GitHub Actions**
 - ✅ Custom domain: (optional, configure if desired)
 - ✅ Enforce HTTPS: **Enabled**
@@ -116,6 +125,7 @@ updates:
 ## Environment Protection Rules
 
 ### PyPI Environment
+
 - Environment name: `pypi`
 - Protection rules:
   - ✅ Required reviewers: Repository owner
@@ -123,6 +133,7 @@ updates:
   - ✅ Deployment branches: Only protected branches
 
 ### TestPyPI Environment  
+
 - Environment name: `testpypi`
 - Protection rules:
   - ✅ Required reviewers: Repository owner
@@ -132,14 +143,17 @@ updates:
 ## Secrets and Variables
 
 ### Repository Secrets
+
 None required.
 
 ### Environment Secrets
+
 No secrets needed for OIDC-based PyPI publishing.
 
 ## Labels Configuration
 
 ### Default Labels to Add
+
 - `good first issue` - Good for newcomers
 - `help wanted` - Extra attention is needed
 - `priority: high` - High priority
@@ -182,6 +196,7 @@ mkdocs.yml @cameronrye
 ## Automation Setup
 
 ### Required GitHub Apps/Integrations
+
 1. **Dependabot**: Already built into GitHub
 2. **GitHub Actions**: Built-in CI/CD
 
@@ -212,6 +227,7 @@ After configuring these settings:
 ## Maintenance
 
 ### Regular Tasks
+
 - Review and update dependencies monthly
 - Monitor security alerts and address promptly
 - Review and merge Dependabot PRs

--- a/docs/gemini-configuration.md
+++ b/docs/gemini-configuration.md
@@ -7,6 +7,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 ### Core Configuration
 
 #### `GEMINI_MAX_RESPONSE_SIZE`
+
 - **Type**: Integer (bytes)
 - **Default**: `1048576` (1MB)
 - **Range**: `1024` - `104857600` (1KB - 100MB)
@@ -14,6 +15,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 - **Example**: `GEMINI_MAX_RESPONSE_SIZE=2097152`
 
 #### `GEMINI_TIMEOUT_SECONDS`
+
 - **Type**: Float (seconds)
 - **Default**: `30.0`
 - **Range**: `1.0` - `300.0`
@@ -23,6 +25,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 ### Caching Configuration
 
 #### `GEMINI_CACHE_ENABLED`
+
 - **Type**: Boolean
 - **Default**: `true`
 - **Values**: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off`
@@ -30,6 +33,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 - **Example**: `GEMINI_CACHE_ENABLED=true`
 
 #### `GEMINI_CACHE_TTL_SECONDS`
+
 - **Type**: Integer (seconds)
 - **Default**: `300` (5 minutes)
 - **Range**: `1` - `86400` (1 second - 24 hours)
@@ -37,6 +41,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 - **Example**: `GEMINI_CACHE_TTL_SECONDS=600`
 
 #### `GEMINI_MAX_CACHE_ENTRIES`
+
 - **Type**: Integer
 - **Default**: `1000`
 - **Range**: `1` - `100000`
@@ -46,30 +51,35 @@ This document provides a comprehensive reference for all Gemini protocol configu
 ### Security Configuration
 
 #### `GEMINI_ALLOWED_HOSTS`
+
 - **Type**: String (comma-separated)
 - **Default**: Empty (all hosts allowed)
 - **Description**: Comma-separated list of allowed Gemini hosts
 - **Example**: `GEMINI_ALLOWED_HOSTS=geminiprotocol.net,warmedal.se,kennedy.gemi.dev`
 
 #### `GEMINI_ALLOW_LOCAL_HOSTS`
+
 - **Type**: Boolean
 - **Default**: `false`
 - **Description**: Allow connections to loopback/private/internal addresses. Disabled by default to prevent SSRF.
 - **Example**: `GEMINI_ALLOW_LOCAL_HOSTS=false`
 
 #### `GEMINI_TOFU_ENABLED`
+
 - **Type**: Boolean
 - **Default**: `true`
 - **Description**: Enable Trust-on-First-Use certificate validation. Gemini TLS runs without CA-chain validation, so TOFU is the only peer authentication; disabling it leaves connections unauthenticated and MITM-able.
 - **Example**: `GEMINI_TOFU_ENABLED=true`
 
 #### `GEMINI_TOFU_REJECT_EXPIRED`
+
 - **Type**: Boolean
 - **Default**: `false`
 - **Description**: Fail closed when a server certificate is outside its validity window (already expired, or not yet valid on first use) instead of pinning it with a warning. Off by default to match the conventional Gemini TOFU model, where the pinned fingerprint is the real authenticator.
 - **Example**: `GEMINI_TOFU_REJECT_EXPIRED=true`
 
 #### `GEMINI_CLIENT_CERTS_ENABLED`
+
 - **Type**: Boolean
 - **Default**: `true`
 - **Description**: Enable automatic client certificate generation and management. Certificates are created and reused per host/path scope on demand; you do not supply cert/key files yourself.
@@ -78,12 +88,14 @@ This document provides a comprehensive reference for all Gemini protocol configu
 ### Storage Configuration
 
 #### `GEMINI_TOFU_STORAGE_PATH`
+
 - **Type**: String (file path)
 - **Default**: `~/.gemini/tofu.json`
 - **Description**: Path to TOFU certificate fingerprint storage file
 - **Example**: `GEMINI_TOFU_STORAGE_PATH=/custom/path/tofu.json`
 
 #### `GEMINI_CLIENT_CERTS_STORAGE_PATH`
+
 - **Type**: String (directory path)
 - **Default**: `~/.gemini/certs/`
 - **Description**: Directory where automatically generated client certificates and their private keys are stored. The directory is created with owner-only (`700`) permissions.
@@ -92,6 +104,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 ### Content and Rate Limiting
 
 #### `GEMINI_MAX_RENDERED_CHARS`
+
 - **Type**: Integer (characters)
 - **Default**: `50000`
 - **Range**: `0` - `10485760` (`0` = unlimited)
@@ -99,6 +112,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 - **Example**: `GEMINI_MAX_RENDERED_CHARS=100000`
 
 #### `GEMINI_REQUESTS_PER_MINUTE`
+
 - **Type**: Float
 - **Default**: `0` (unlimited)
 - **Range**: `0` - `6000`
@@ -106,6 +120,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 - **Example**: `GEMINI_REQUESTS_PER_MINUTE=60`
 
 #### `GEMINI_MAX_CONCURRENT_REQUESTS`
+
 - **Type**: Integer
 - **Default**: `0` (unlimited)
 - **Range**: `0` - `1000`
@@ -113,6 +128,7 @@ This document provides a comprehensive reference for all Gemini protocol configu
 - **Example**: `GEMINI_MAX_CONCURRENT_REQUESTS=20`
 
 #### `GEMINI_DENIED_MIME_TYPES`
+
 - **Type**: String (comma-separated)
 - **Default**: Empty (no content filtering)
 - **Description**: MIME types, or `type/*` wildcards, to reject as filtered content. Empty means no content filtering.
@@ -187,6 +203,7 @@ uv run task validate-config
 ```
 
 The validator checks:
+
 - Value ranges and types
 - File path existence
 - Boolean value formats
@@ -217,18 +234,21 @@ The validator checks:
 ### Common Configuration Issues
 
 1. **Invalid Boolean Values**
+
    ```
    Error: GEMINI_CACHE_ENABLED must be a boolean value
    Solution: Use true/false, 1/0, yes/no, on/off
    ```
 
 2. **File Path Issues**
+
    ```
    Error: TOFU storage directory not writable
    Solution: Check directory permissions and ownership
    ```
 
 3. **TOFU Certificate Mismatch**
+
    ```
    Error: TOFU validation failed: certificate fingerprint changed
    Solution: Confirm the server legitimately rotated its certificate, then remove the

--- a/docs/gemini-specification-for-llms.md
+++ b/docs/gemini-specification-for-llms.md
@@ -70,6 +70,7 @@ Client connects via TLS → Sends URL + CRLF → Server responds with status + m
 ```
 
 **Requirements:**
+
 - URI MUST NOT exceed 1024 bytes
 - MUST be absolute URI (no relative URIs)
 - MUST NOT include userinfo portion
@@ -83,6 +84,7 @@ Client connects via TLS → Sends URL + CRLF → Server responds with status + m
 ```
 
 **Components:**
+
 - **status**: Two-digit code (10-69)
 - **meta**: Additional information (depends on status)
 - **body**: Optional content (depends on status and MIME type)
@@ -144,11 +146,13 @@ gemini://<host>[:<port>][/<path>][?<query>]
 **Format**: `1x <prompt>`
 
 **Status 10 - Input**
+
 - Server needs user input
 - Client MUST prompt user with provided text
 - Resubmit request with input as query string
 
 **Status 11 - Sensitive Input**
+
 - Same as 10 but for passwords/sensitive data
 - Client SHOULD NOT echo input to screen
 
@@ -157,6 +161,7 @@ gemini://<host>[:<port>][/<path>][?<query>]
 **Format**: `2x <mimetype>`
 
 **Status 20 - Success**
+
 - Request successful
 - Meta field contains MIME type
 - Body contains requested content
@@ -166,10 +171,12 @@ gemini://<host>[:<port>][/<path>][?<query>]
 **Format**: `3x <new-URI>`
 
 **Status 30 - Temporary Redirect**
+
 - Content temporarily moved
 - Continue using original URI for future requests
 
 **Status 31 - Permanent Redirect**
+
 - Content permanently moved
 - Update bookmarks to new URI
 
@@ -208,6 +215,7 @@ gemini://<host>[:<port>][/<path>][?<query>]
 ### Required Support
 
 **Clients MUST support:**
+
 - `text/gemini; charset=utf-8` (native hypertext format)
 - `text/plain; charset=utf-8` (plain text)
 - `text/plain; charset=us-ascii` (ASCII text)
@@ -223,10 +231,12 @@ gemini://<host>[:<port>][/<path>][?<query>]
 ### MIME Parameters
 
 **For text/gemini:**
+
 - `charset`: Character encoding (default: UTF-8)
 - `lang`: Language tag per BCP47 (optional)
 
 **Examples:**
+
 ```
 text/gemini
 text/gemini; charset=utf-8
@@ -250,22 +260,26 @@ Gemtext is the native hypertext format for Gemini, designed for simplicity and a
 1. **Text lines** (default)
 2. **Link lines** (`=>`)
 3. **Heading lines** (`#`, `##`, `###`)
-4. **List items** (`* `)
+4. **List items** (`*`)
 5. **Quote lines** (`>`)
 6. **Preformat toggle** (` ``` `)
 
 ### Core Line Types (MUST Support)
 
 **Text Lines**
+
 - Default line type (no special prefix)
 - Rendered as flowing text with wrapping
 - Empty lines create vertical space
 
 **Link Lines**
+
 ```
 =>[<whitespace>]<URL>[<whitespace><link-text>]
 ```
+
 Examples:
+
 ```
 => gemini://example.org/
 => gemini://example.org/ Example Site
@@ -274,9 +288,11 @@ Examples:
 ```
 
 **Preformat Toggle Lines**
+
 ```
 ```[<alt-text>]
 ```
+
 - Toggles between normal and preformatted mode
 - Alt text optional (for accessibility/syntax highlighting)
 - Content between toggles rendered in monospace
@@ -284,6 +300,7 @@ Examples:
 ### Optional Line Types (MAY Support)
 
 **Heading Lines**
+
 ```
 # Heading Level 1
 ## Heading Level 2
@@ -291,6 +308,7 @@ Examples:
 ```
 
 **List Items**
+
 ```
 * First item
 * Second item
@@ -298,6 +316,7 @@ Examples:
 ```
 
 **Quote Lines**
+
 ```
 > This is a quote
 > from another source
@@ -323,12 +342,14 @@ Examples:
 ### Certificate Validation
 
 **Trust on First Use (TOFU) - Strongly Recommended:**
+
 1. Accept any certificate on first connection
 2. Store certificate fingerprint and expiry
 3. Verify fingerprint matches on subsequent connections
 4. Warn user if fingerprint changes before expiry
 
 **Alternative approaches:**
+
 - Traditional CA validation
 - DANE (DNS-Based Authentication of Named Entities)
 - Manual certificate pinning
@@ -336,11 +357,13 @@ Examples:
 ### Client Certificates
 
 **Usage scenarios:**
+
 - Access control to protected resources
 - Maintaining server-side state
 - User authentication
 
 **Scope limitations:**
+
 - Limited to specific host, port, and path
 - MUST NOT be reused across different hosts
 - User MUST be involved in certificate generation
@@ -359,6 +382,7 @@ Examples:
 ### Client Requirements
 
 **MUST:**
+
 - Support TLS 1.2+
 - Include SNI in TLS handshake
 - Limit URI length to 1024 bytes
@@ -367,12 +391,14 @@ Examples:
 - Limit redirections to 5 maximum
 
 **SHOULD:**
+
 - Implement TOFU certificate validation
 - Warn users about TLS 1.2 certificate exposure
 - Display error messages to users
 - Support client certificate generation
 
 **MAY:**
+
 - Support additional MIME types
 - Implement proxy support
 - Provide certificate management UI
@@ -380,6 +406,7 @@ Examples:
 ### Server Requirements
 
 **MUST:**
+
 - Support TLS 1.2+
 - Use TLS close_notify to close connections
 - Reject URIs exceeding 1024 bytes
@@ -388,12 +415,14 @@ Examples:
 - Handle both empty path and "/" equivalently
 
 **SHOULD:**
+
 - Support client certificates for access control
 - Provide meaningful error messages
 - Implement rate limiting (status 44)
 - Log security events
 
 **MAY:**
+
 - Support dynamic content generation
 - Implement proxy functionality
 - Provide server-side state management
@@ -412,11 +441,13 @@ Examples:
 ### Basic Content Request
 
 **Client Request:**
+
 ```
 gemini://example.org/document.gmi
 ```
 
 **Server Response:**
+
 ```
 20 text/gemini
 # Welcome to Example.org
@@ -430,21 +461,25 @@ This is a sample gemtext document.
 ### User Input Example
 
 **Initial Request:**
+
 ```
 gemini://example.org/search
 ```
 
 **Server Response:**
+
 ```
 10 Enter search terms
 ```
 
 **Follow-up Request:**
+
 ```
 gemini://example.org/search?gemini%20protocol
 ```
 
 **Server Response:**
+
 ```
 20 text/gemini
 # Search Results
@@ -456,21 +491,25 @@ gemini://example.org/search?gemini%20protocol
 ### Client Certificate Example
 
 **Initial Request:**
+
 ```
 gemini://example.org/private/
 ```
 
 **Server Response:**
+
 ```
 60 Certificate required for access
 ```
 
 **Subsequent Request (with certificate):**
+
 ```
 gemini://example.org/private/
 ```
 
 **Server Response:**
+
 ```
 20 text/gemini
 # Private Area
@@ -481,21 +520,25 @@ Welcome to the protected section.
 ### Redirection Example
 
 **Client Request:**
+
 ```
 gemini://example.org/old-path
 ```
 
 **Server Response:**
+
 ```
 31 /new-path
 ```
 
 **Follow-up Request:**
+
 ```
 gemini://example.org/new-path
 ```
 
 **Server Response:**
+
 ```
 20 text/gemini
 # New Location
@@ -506,11 +549,13 @@ Content has moved here permanently.
 ### Error Handling Example
 
 **Client Request:**
+
 ```
 gemini://example.org/nonexistent
 ```
 
 **Server Response:**
+
 ```
 51 The requested resource was not found
 ```
@@ -520,29 +565,33 @@ gemini://example.org/nonexistent
 **State Management with Client Certificates:**
 
 1. **Certificate Request:**
-```
-Client: gemini://example.org/app/
-Server: 60 Certificate required for state management
-```
+
+   ```
+   Client: gemini://example.org/app/
+   Server: 60 Certificate required for state management
+   ```
 
 2. **First Input:**
-```
-Client: gemini://example.org/app/ (with certificate)
-Server: 10 Enter first number (0-9000)
-```
+
+   ```
+   Client: gemini://example.org/app/ (with certificate)
+   Server: 10 Enter first number (0-9000)
+   ```
 
 3. **Store First Value:**
-```
-Client: gemini://example.org/app/?42 (with certificate)
-Server: 10 Enter second number (0-9000)
-```
+
+   ```
+   Client: gemini://example.org/app/?42 (with certificate)
+   Server: 10 Enter second number (0-9000)
+   ```
 
 4. **Calculate Result:**
-```
-Client: gemini://example.org/app/?1923 (with certificate)
-Server: 20 text/plain
-42 plus 1923 equals 1965, have a nice day!
-```
+
+   ```
+   Client: gemini://example.org/app/?1923 (with certificate)
+   Server: 20 text/plain
+   42 plus 1923 equals 1965, have a nice day!
+   ```
 
 ---
 
@@ -583,17 +632,20 @@ Server: 20 text/plain
 ### Security Model
 
 **Trust on First Use (TOFU):**
+
 - Accept any certificate on first connection
 - Detect certificate changes as potential attacks
 - User involvement in trust decisions
 - No reliance on Certificate Authorities
 
 **Advantages:**
+
 - Supports self-signed certificates
 - Reduces dependency on CA infrastructure
 - User control over trust decisions
 
 **Limitations:**
+
 - Vulnerable to first-connection attacks
 - Requires user education
 - Certificate management complexity
@@ -601,16 +653,19 @@ Server: 20 text/plain
 ### Privacy Features
 
 **Mandatory encryption:**
+
 - All connections encrypted via TLS
 - No plaintext fallback option
 - Protection against passive surveillance
 
 **No tracking mechanisms:**
+
 - No cookies or persistent state
 - No referrer headers
 - Minimal metadata exposure
 
 **Certificate privacy:**
+
 - TLS 1.2 exposes certificates in handshake
 - TLS 1.3 provides better certificate privacy
 - Client certificates only when explicitly required
@@ -618,11 +673,13 @@ Server: 20 text/plain
 ### Threat Model
 
 **Protected against:**
+
 - Passive network surveillance
 - Content modification in transit
 - Server impersonation (with TOFU)
 
 **Not protected against:**
+
 - Active attacks on first connection
 - Compromised client or server
 - Traffic analysis (connection patterns)
@@ -631,18 +688,21 @@ Server: 20 text/plain
 ### Best Practices
 
 **For clients:**
+
 - Implement TOFU certificate validation
 - Warn users about certificate changes
 - Provide certificate management interface
 - Support TLS 1.3 when available
 
 **For servers:**
+
 - Use strong TLS configuration
 - Implement rate limiting
 - Monitor for suspicious activity
 - Provide clear error messages
 
 **For users:**
+
 - Verify certificates on first connection
 - Be cautious with client certificates
 - Use trusted proxy servers only
@@ -719,6 +779,7 @@ port       = 1*5DIGIT ; 0-65535, default 1965
 ### Client Implementation
 
 **Core Requirements:**
+
 - [ ] TCP connection to port 1965
 - [ ] TLS 1.2+ support with SNI
 - [ ] URI validation (max 1024 bytes)
@@ -730,6 +791,7 @@ port       = 1*5DIGIT ; 0-65535, default 1965
 - [ ] Error display to user
 
 **Security Features:**
+
 - [ ] TOFU certificate validation
 - [ ] Certificate fingerprint storage
 - [ ] Certificate change warnings
@@ -737,6 +799,7 @@ port       = 1*5DIGIT ; 0-65535, default 1965
 - [ ] TLS close_notify handling
 
 **Gemtext Support:**
+
 - [ ] Text line rendering
 - [ ] Link line parsing and display
 - [ ] Preformat toggle handling
@@ -746,6 +809,7 @@ port       = 1*5DIGIT ; 0-65535, default 1965
 ### Server Implementation
 
 **Core Requirements:**
+
 - [ ] TCP server on port 1965
 - [ ] TLS 1.2+ support
 - [ ] Request parsing and validation
@@ -756,6 +820,7 @@ port       = 1*5DIGIT ; 0-65535, default 1965
 - [ ] Connection closing with TLS close_notify
 
 **Content Serving:**
+
 - [ ] Static file serving
 - [ ] Directory listing (optional)
 - [ ] Dynamic content support (optional)
@@ -763,6 +828,7 @@ port       = 1*5DIGIT ; 0-65535, default 1965
 - [ ] User input processing
 
 **Security Features:**
+
 - [ ] Input validation
 - [ ] Rate limiting (status 44)
 - [ ] Access control

--- a/docs/gemini-troubleshooting.md
+++ b/docs/gemini-troubleshooting.md
@@ -7,14 +7,17 @@ This document provides troubleshooting guidance and answers to frequently asked 
 ### TLS Connection Issues
 
 #### Problem: TLS Handshake Failures
+
 ```
 Error: TLS handshake failed: [SSL: CERTIFICATE_VERIFY_FAILED]
 ```
 
 **Causes and Solutions:**
+
 1. **TOFU Certificate Mismatch**
    - **Cause**: Server certificate has changed since first connection
    - **Solution**: Clear TOFU storage or manually update fingerprint
+
    ```bash
    rm ~/.gemini/tofu.json
    # Or edit the file to remove the specific host entry
@@ -29,54 +32,66 @@ Error: TLS handshake failed: [SSL: CERTIFICATE_VERIFY_FAILED]
    - **Solution**: Ensure hostname is properly set in URL
 
 #### Problem: TOFU Fingerprint Mismatch
+
 ```
 Error: TOFU validation failed: certificate fingerprint changed
 ```
 
 **Solutions:**
+
 1. **Confirm the certificate change is legitimate**
    - A changed fingerprint can mean the server rotated its certificate — or an active MITM. Verify out-of-band before trusting it.
 
 2. **Re-pin the certificate**
+
    ```bash
    # Remove the stale host entry from ~/.gemini/tofu.json, or delete the
    # file to re-pin every host on the next connection
    rm ~/.gemini/tofu.json
    ```
+
    - Note: Gemini trusts server certificates via TOFU (pinned fingerprint), not CA-chain or hostname verification, so there is no hostname-verification toggle.
 
 ### Client Certificate Issues
 
 #### Problem: Client Certificate Generation Fails
+
 ```
 Error: Failed to generate client certificate
 ```
 
 **Solutions:**
+
 1. **Check Directory Permissions**
+
    ```bash
    mkdir -p ~/.gemini/certs
    chmod 700 ~/.gemini/certs
    ```
 
 2. **Verify OpenSSL Installation**
+
    ```bash
    openssl version
    # Should show OpenSSL version
    ```
 
 3. **Check Disk Space**
+
    ```bash
    df -h ~/.gemini/
    ```
 
 #### Problem: Client Certificate Not Sent
+
 ```
 Error: Server requested client certificate but none available
 ```
 
 **Solutions:**
+
 1. **Enable Client Certificates**
+
    ```bash
    export GEMINI_CLIENT_CERTS_ENABLED=true
    ```
@@ -88,17 +103,21 @@ Error: Server requested client certificate but none available
 ### Connection and Timeout Issues
 
 #### Problem: Connection Timeouts
+
 ```
 Error: Connection timeout after 30 seconds
 ```
 
 **Solutions:**
+
 1. **Increase Timeout**
+
    ```bash
    export GEMINI_TIMEOUT_SECONDS=60
    ```
 
 2. **Check Network Connectivity**
+
    ```bash
    ping geminiprotocol.net
    telnet geminiprotocol.net 1965
@@ -109,17 +128,21 @@ Error: Connection timeout after 30 seconds
    - Check if server is temporarily down
 
 #### Problem: DNS Resolution Failures
+
 ```
 Error: Name or service not known
 ```
 
 **Solutions:**
+
 1. **Check DNS Configuration**
+
    ```bash
    nslookup geminiprotocol.net
    ```
 
 2. **Try Alternative DNS**
+
    ```bash
    # Query a specific resolver to rule out local DNS problems
    nslookup geminiprotocol.net 8.8.8.8
@@ -128,26 +151,31 @@ Error: Name or service not known
 ### Protocol and Content Issues
 
 #### Problem: Invalid Gemini Response
+
 ```
 Error: Invalid status code: 99
 ```
 
 **Solutions:**
+
 1. **Check Server Compliance**
    - Verify server implements Gemini protocol correctly
    - Try with reference Gemini client
 
 2. **Enable Debug Logging**
+
    ```bash
    export GOPHER_MCP_LOG_LEVEL=DEBUG
    ```
 
 #### Problem: Gemtext Parsing Errors
+
 ```
 Error: Failed to parse gemtext content
 ```
 
 **Solutions:**
+
 1. **Check Content Encoding**
    - Verify content is UTF-8 encoded
    - Check for BOM or encoding issues
@@ -159,22 +187,27 @@ Error: Failed to parse gemtext content
 ### Configuration Issues
 
 #### Problem: Invalid Configuration Values
+
 ```
 Error: GEMINI_CACHE_TTL_SECONDS must be between 1 and 86400
 ```
 
 **Solutions:**
+
 1. **Use Configuration Validator**
+
    ```bash
    python scripts/validate-config.py
    ```
 
 2. **Check Environment Variables**
+
    ```bash
    env | grep GEMINI_
    ```
 
 3. **Reset to Defaults**
+
    ```bash
    unset GEMINI_CACHE_TTL_SECONDS
    # Will use default value
@@ -209,6 +242,7 @@ A: No, client certificates are optional. They're only needed for servers that re
 **Q: How secure is the Gemini implementation?**
 
 A: The implementation follows security best practices:
+
 - Mandatory TLS 1.2+ encryption
 - TOFU certificate validation
 - Client certificate support
@@ -228,6 +262,7 @@ A: Yes, set `GEMINI_CACHE_ENABLED=false` to disable Gemini caching. Gopher cachi
 **Q: What are the performance characteristics?**
 
 A: Performance depends on network conditions and server responsiveness. Typical response times:
+
 - Cached responses: < 1ms
 - Local network: 10-50ms
 - Internet connections: 100-2000ms
@@ -237,6 +272,7 @@ A: Performance depends on network conditions and server responsiveness. Typical 
 **Q: Where are certificates stored?**
 
 A: By default:
+
 - TOFU fingerprints: `~/.gemini/tofu.json`
 - Client certificates: `~/.gemini/certs/`
 
@@ -255,11 +291,13 @@ A: No — client certificates are generated and managed automatically per host/p
 ### Built-in Diagnostics
 
 1. **Configuration Validator**
+
    ```bash
    python scripts/validate-config.py
    ```
 
 2. **Verify the Installation**
+
    ```bash
    python -c "import gopher_mcp; print(gopher_mcp.__version__)"
    ```
@@ -267,16 +305,19 @@ A: No — client certificates are generated and managed automatically per host/p
 ### External Tools
 
 1. **OpenSSL for TLS Testing**
+
    ```bash
    openssl s_client -connect geminiprotocol.net:1965 -servername geminiprotocol.net
    ```
 
 2. **Network Connectivity**
+
    ```bash
    nc -zv geminiprotocol.net 1965
    ```
 
 3. **Certificate Information**
+
    ```bash
    echo | openssl s_client -connect geminiprotocol.net:1965 -servername geminiprotocol.net 2>/dev/null | openssl x509 -noout -text
    ```
@@ -290,6 +331,7 @@ export GOPHER_MCP_LOG_LEVEL=DEBUG
 ```
 
 This will provide detailed information about:
+
 - TLS handshake process
 - Certificate validation steps
 - Request/response details
@@ -312,6 +354,7 @@ If you encounter issues not covered in this guide:
 ### Memory Usage
 
 Bound memory growth through configuration rather than runtime inspection:
+
 ```bash
 # Cap cached entries and rendered output to limit memory use
 export GEMINI_MAX_CACHE_ENTRIES=1000
@@ -321,6 +364,7 @@ export GEMINI_MAX_RENDERED_CHARS=50000
 ### Connection Optimization
 
 For high-throughput scenarios, cap simultaneous fetches and rate-limit per host:
+
 ```bash
 export GEMINI_MAX_CONCURRENT_REQUESTS=20
 export GEMINI_REQUESTS_PER_MINUTE=60
@@ -329,6 +373,7 @@ export GEMINI_REQUESTS_PER_MINUTE=60
 ### Cache Tuning
 
 Optimize cache settings based on usage:
+
 ```bash
 # For high-traffic scenarios
 export GEMINI_MAX_CACHE_ENTRIES=5000

--- a/docs/gopher-specification-for-llms.md
+++ b/docs/gopher-specification-for-llms.md
@@ -80,6 +80,7 @@ gopher://<host>:<port>/<gopher-path>
 ```
 
 Where `<gopher-path>` is one of:
+
 - `<gophertype><selector>`
 - `<gophertype><selector>%09<search>`
 - `<gophertype><selector>%09<search>%09<gopher+_string>`
@@ -131,11 +132,13 @@ Where `<gopher-path>` is one of:
 ### Menu Format
 
 Each menu line follows this exact format:
+
 ```
 <type><display_string><TAB><selector><TAB><host><TAB><port><CRLF>
 ```
 
 **Components:**
+
 - **type**: Single character item type
 - **display_string**: Human-readable name (≤70 characters recommended)
 - **selector**: Selector string for retrieving this item
@@ -163,11 +166,13 @@ Each menu line follows this exact format:
 ### Menu Transaction (Type 1)
 
 **Client Request:**
+
 ```
 <selector><CRLF>
 ```
 
 **Server Response:**
+
 ```
 <type><display><TAB><selector><TAB><host><TAB><port><CRLF>
 <type><display><TAB><selector><TAB><host><TAB><port><CRLF>
@@ -178,11 +183,13 @@ Each menu line follows this exact format:
 ### Text File Transaction (Type 0)
 
 **Client Request:**
+
 ```
 <selector><CRLF>
 ```
 
 **Server Response:**
+
 ```
 <text_content>
 .<CRLF>
@@ -191,17 +198,20 @@ Each menu line follows this exact format:
 ### Search Transaction (Type 7)
 
 **Client Request:**
+
 ```
 <selector><TAB><search_string><CRLF>
 ```
 
 **Server Response:**
+
 ```
 <menu_format_results>
 .<CRLF>
 ```
 
 **Search Logic:**
+
 - Spaces typically treated as Boolean AND
 - Returns virtual directory listing of matching documents
 - Search string follows selector with TAB separator
@@ -209,11 +219,13 @@ Each menu line follows this exact format:
 ### Binary Transaction (Types 4, 5, 6, 9, g, I)
 
 **Client Request:**
+
 ```
 <selector><CRLF>
 ```
 
 **Server Response:**
+
 ```
 <binary_data>
 <connection_closes>
@@ -228,6 +240,7 @@ Each menu line follows this exact format:
 ### Overview
 
 Gopher+ provides upward-compatible extensions to base Gopher protocol, supporting:
+
 - Item attributes
 - Alternate data representations
 - Electronic forms
@@ -236,6 +249,7 @@ Gopher+ provides upward-compatible extensions to base Gopher protocol, supportin
 ### Gopher+ Item Identification
 
 In directory listings, Gopher+ items are tagged:
+
 - `+`: Standard Gopher+ item
 - `?`: Gopher+ item with electronic form (+ASK)
 
@@ -294,6 +308,7 @@ In directory listings, Gopher+ items are tagged:
 ### Security Limitations
 
 ⚠️ **Critical Security Issues:**
+
 - **No encryption**: All data transmitted in plaintext
 - **No authentication**: Passwords (if used) sent in clear
 - **No privacy**: Assume all communications are public
@@ -320,40 +335,46 @@ In directory listings, Gopher+ items are tagged:
 ### Basic Directory Listing
 
 **Request:**
+
 ```
 <empty_line>
 ```
 
 **Response:**
+
 ```
-0About Gopher	about	gopher.example.com	70
-1Documents	docs/	gopher.example.com	70
-7Search	search	search.example.com	70
+0About Gopher about gopher.example.com 70
+1Documents docs/ gopher.example.com 70
+7Search search search.example.com 70
 .
 ```
 
 ### Search Example
 
 **Request:**
+
 ```
-search	python programming
+search python programming
 ```
 
 **Response:**
+
 ```
-0Python Tutorial	tutorials/python.txt	docs.example.com	70
-0Python Reference	ref/python.txt	docs.example.com	70
+0Python Tutorial tutorials/python.txt docs.example.com 70
+0Python Reference ref/python.txt docs.example.com 70
 .
 ```
 
 ### Gopher+ Attribute Request
 
 **Request:**
+
 ```
-document.txt		!+ABSTRACT
+document.txt  !+ABSTRACT
 ```
 
 **Response:**
+
 ```
 +ABSTRACT: This document contains programming examples
 .

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -9,6 +9,7 @@ The server added comprehensive Gemini protocol support (introduced in v0.2.0) al
 ## What's New
 
 ### New Features
+
 - **Gemini Protocol Support**: Full implementation of Gemini v0.24.1
 - **`gemini_fetch` Tool**: New MCP tool for Gemini protocol access
 - **TLS Security**: Mandatory TLS with TOFU certificate validation
@@ -17,6 +18,7 @@ The server added comprehensive Gemini protocol support (introduced in v0.2.0) al
 - **Dual Caching**: Separate cache systems for each protocol
 
 ### Backward Compatibility
+
 - ✅ All existing `gopher_fetch` functionality preserved
 - ✅ Existing configuration variables unchanged
 - ✅ No breaking changes to API or behavior
@@ -27,11 +29,13 @@ The server added comprehensive Gemini protocol support (introduced in v0.2.0) al
 ### 1. Update Dependencies
 
 If you're using pip:
+
 ```bash
 pip install --upgrade gopher-mcp
 ```
 
 If you're using uv:
+
 ```bash
 uv sync
 ```
@@ -136,6 +140,7 @@ python scripts/validate-config.py
 **After**: Gopher settings unchanged, can optionally configure Gemini
 
 **Action Required**:
+
 1. Keep existing configuration
 2. Optionally add Gemini-specific settings if desired
 
@@ -145,6 +150,7 @@ python scripts/validate-config.py
 **After**: Same Gopher security, plus enhanced Gemini security
 
 **Recommended Actions**:
+
 ```bash
 # Keep existing Gopher allowlist
 GOPHER_ALLOWED_HOSTS=trusted-gopher-hosts.com
@@ -162,6 +168,7 @@ GEMINI_TOFU_ENABLED=true
 **After**: Can optimize both protocols independently
 
 **Recommended Actions**:
+
 ```bash
 # Keep existing Gopher optimization
 GOPHER_CACHE_TTL_SECONDS=1800
@@ -178,6 +185,7 @@ GEMINI_MAX_CACHE_ENTRIES=5000
 
 **Cause**: Incomplete installation or environment issues
 **Solution**:
+
 ```bash
 # Reinstall completely
 pip uninstall gopher-mcp
@@ -191,6 +199,7 @@ uv sync --reinstall
 
 **Cause**: Invalid configuration values
 **Solution**:
+
 ```bash
 # Run validation to see specific issues
 python scripts/validate-config.py
@@ -203,6 +212,7 @@ unset PROBLEMATIC_VARIABLE
 
 **Cause**: Network or TLS configuration issues
 **Solution**:
+
 ```bash
 # Test with relaxed security (development only)
 export GEMINI_TOFU_ENABLED=false
@@ -215,6 +225,7 @@ ping geminiprotocol.net
 
 **Cause**: Permission or disk space issues
 **Solution**:
+
 ```bash
 # Check and fix permissions
 mkdir -p ~/.gemini
@@ -306,11 +317,13 @@ python -m pytest tests/test_server.py -v
 If you encounter issues during migration:
 
 1. **Check the logs** with debug logging enabled:
+
    ```bash
    export GOPHER_MCP_LOG_LEVEL=DEBUG
    ```
 
 2. **Validate your configuration**:
+
    ```bash
    python scripts/validate-config.py
    ```

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,0 +1,81 @@
+# Data Models
+
+Authoritative, auto-generated reference for the Pydantic models that define tool
+inputs and outputs. These are generated directly from
+[`gopher_mcp.models`](https://github.com/cameronrye/gopher-mcp/blob/main/src/gopher_mcp/models.py),
+so they never drift from the code. For usage examples and error-handling
+recipes, see the [API Reference](../api-reference.md).
+
+## Request Models
+
+::: gopher_mcp.models.GopherFetchRequest
+
+::: gopher_mcp.models.GeminiFetchRequest
+
+## Gopher Result Models
+
+::: gopher_mcp.models.GopherMenuItem
+
+::: gopher_mcp.models.MenuResult
+
+::: gopher_mcp.models.TextResult
+
+::: gopher_mcp.models.BinaryResult
+
+::: gopher_mcp.models.ErrorResult
+
+## Gemini Result Models
+
+::: gopher_mcp.models.GeminiSuccessResult
+
+::: gopher_mcp.models.GeminiGemtextResult
+
+::: gopher_mcp.models.GeminiInputResult
+
+::: gopher_mcp.models.GeminiRedirectResult
+
+::: gopher_mcp.models.GeminiErrorResult
+
+::: gopher_mcp.models.GeminiCertificateResult
+
+## Gemtext Document Models
+
+::: gopher_mcp.models.GemtextDocument
+
+::: gopher_mcp.models.GemtextLine
+
+::: gopher_mcp.models.GemtextLink
+
+::: gopher_mcp.models.GemtextHeading
+
+::: gopher_mcp.models.GemtextList
+
+::: gopher_mcp.models.GemtextQuote
+
+::: gopher_mcp.models.GemtextPreformat
+
+::: gopher_mcp.models.GemtextLineType
+
+## MIME and Protocol Types
+
+::: gopher_mcp.models.GeminiMimeType
+
+::: gopher_mcp.models.GeminiStatusCode
+
+::: gopher_mcp.models.GeminiResponse
+
+## URL Models
+
+::: gopher_mcp.models.GopherURL
+
+::: gopher_mcp.models.GeminiURL
+
+## Caching and Security Models
+
+::: gopher_mcp.models.CacheEntry
+
+::: gopher_mcp.models.GeminiCacheEntry
+
+::: gopher_mcp.models.GeminiCertificateInfo
+
+::: gopher_mcp.models.TOFUEntry

--- a/docs/task-runner.md
+++ b/docs/task-runner.md
@@ -40,10 +40,12 @@ uv run task <command>
 Run `python task.py help` to see all available commands, organized by category:
 
 ### Setup
+
 - `dev-setup` - Set up development environment
 - `install-hooks` - Install pre-commit hooks
 
 ### Code Quality
+
 - `lint` - Run ruff linting
 - `format` - Format code with ruff
 - `typecheck` - Run mypy type checking
@@ -51,6 +53,7 @@ Run `python task.py help` to see all available commands, organized by category:
 - `check` - Run lint + typecheck
 
 ### Testing
+
 - `test` - Run all tests
 - `test-cov` - Run tests with coverage
 - `test-unit` - Run unit tests only
@@ -58,14 +61,17 @@ Run `python task.py help` to see all available commands, organized by category:
 - `test-slow` - Run slow tests
 
 ### Server
+
 - `serve` - Run MCP server (stdio)
 - `serve-http` - Run MCP server (HTTP)
 
 ### Documentation
+
 - `docs-serve` - Serve docs locally
 - `docs-build` - Build documentation
 
 ### Maintenance
+
 - `clean` - Clean build artifacts
 - `ci` - Run CI pipeline locally
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - Gemini Troubleshooting: gemini-troubleshooting.md
   - Reference:
       - Architecture: architecture.md
+      - Data Models: reference/models.md
       - Migration Guide: migration-guide.md
   - Development:
       - Contributing: contributing.md
@@ -73,6 +74,11 @@ plugins:
             separate_signature: true
             show_signature_annotations: true
             signature_crossrefs: true
+            show_if_no_docstring: true
+            members_order: source
+            show_labels: true
+            inherited_members: true
+            filters: ["!^_"]
 
 markdown_extensions:
   - admonition

--- a/src/gopher_mcp/models.py
+++ b/src/gopher_mcp/models.py
@@ -174,7 +174,7 @@ class CacheEntry(_BaseCacheEntry[GopherFetchResponse]):
 class GeminiURL(BaseModel):
     """Model for parsed Gemini URLs.
 
-    Based on gemini://<host>[:<port>][/<path>][?<query>] format.
+    Based on the ``gemini://<host>[:<port>][/<path>][?<query>]`` format.
     """
 
     host: str = Field(..., description="Hostname or IP address")


### PR DESCRIPTION
## 📝 Description

Three documentation-tooling improvements that build on the recent docs
consolidation (#49). All are verified locally with `mkdocs build --clean
--strict` and the full pre-commit suite.

### 1. Auto-generated data-model reference (kills API-doc drift)

- New generated page **`docs/reference/models.md`** rendered directly from the
  Pydantic models via `mkdocstrings` (already a configured plugin), wired into
  the **Reference** nav.
- Replaced the hand-written TypeScript-style `interface {}` blocks in
  `api-reference.md` with tables that cross-link to the generated definitions.
  Those blocks had **drifted and were materially wrong** — e.g. `display_text`
  (real: `title`), `server_info` (doesn't exist), `content`/`size` (real:
  `text`/`bytes`), `main_type`/`sub_type` (real: `type`/`subtype`), and the
  `ServerInfo`/`RequestInfo` interfaces describe models that don't exist.
- Added the recommended `mkdocstrings` handler options (`inherited_members`,
  `filters`, `show_if_no_docstring`, `members_order: source`, `show_labels`) for
  clean Pydantic rendering.
- One small `models.py` docstring change: backtick-wrap a URL grammar so
  autorefs doesn't try to resolve `[/<path>]` as a cross-reference (keeps the
  `--strict` build clean). No behavior change.

### 2. markdownlint on `docs/`

- Dropped `docs/` from the markdownlint pre-commit exclude so the docs tree is
  now linted.
- Relaxed the rules that conflict with a prose docs site in `.markdownlint.json`:
  `MD013` (line length) off, `MD040` (language-on-fences) off, `MD024`
  `siblings_only`, `MD029` `ordered`. `MD033`/`MD036` unchanged.
- One ordered list in `gemini-specification-for-llms.md` was re-indented so its
  fenced code blocks attach to their list items; everything else was auto-fixed
  (blank-line normalization, tabs→spaces). **Prettier still excludes `docs/`**,
  so there's no formatter conflict.

### 3. CHANGELOG entry

- Added an `[Unreleased]` entry documenting the documentation overhaul
  (consolidation, `wiki-content/` removal, accuracy fixes, the generated model
  reference, and docs linting).

## 🧪 Type of Change

- [x] 📚 Documentation update
- [x] 🏗️ Build/CI improvement (markdownlint on docs/)

## 🧪 Testing

```bash
uv run --extra docs mkdocs build --clean --strict   # passes; all model cross-refs resolve
uv run pre-commit run --all-files                   # all hooks pass (incl. markdownlint on docs/, ruff, mypy)
```

Verified the generated page renders the **real** fields (`title`, `next_url`,
`subtype`, `request_info`) and none of the old wrong ones, and that
`api-reference.md` resolves its cross-links to the models page.

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## 🎯 Reviewer Focus Areas

- `docs/reference/models.md` + the `mkdocstrings` options in `mkdocs.yml` — the
  generated rendering of the Pydantic models.
- `.markdownlint.json` rule relaxations — confirm they match how you want the
  docs linted.
