### PR TITLE
chore(release): 0.4.1 — fix doc example keys, add serialization contract test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-08
+
+### Added
+
+- Serialization-contract tests that pin the public result models' `model_dump()`
+  key sets, guarding the documented response shape against silent drift.
+
 ### Changed
 
 - Made the published documentation site the single source of truth: consolidated
@@ -36,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   environment variables and stale single-tool / source-only / Pituophis /
   `tools.py` / `GopherMCPServer` claims from the documentation, and corrected the
   documented response-model fields to match the code.
+- Corrected the documentation code examples to access the real serialized
+  response keys (`title`, `text`/`bytes`, `note`, `new_url`, and the nested
+  `error` object), so the examples run without raising `KeyError`.
 
 ## [0.4.0] - 2026-06-08
 
@@ -258,7 +268,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extensive test suite with >90% coverage
 - Complete documentation and examples
 
-[Unreleased]: https://github.com/cameronrye/gopher-mcp/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/cameronrye/gopher-mcp/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/cameronrye/gopher-mcp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/cameronrye/gopher-mcp/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/cameronrye/gopher-mcp/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/cameronrye/gopher-mcp/compare/v0.2.1...v0.2.2

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Fetches Gopher menus, text files, or metadata by URL with comprehensive error ha
 **Response Types:**
 
 - **MenuResult**: For Gopher menus (type 1) and search results (type 7)
-  - Contains structured menu items with type, display text, selector, host, and port
+  - Contains structured menu items with type, title, selector, host, and port
 - **TextResult**: For text files (type 0)
   - Returns the full text content with metadata
 - **BinaryResult**: Metadata only for binary files (types 4, 5, 6, 9, g, I)
@@ -214,7 +214,7 @@ Fetches Gemini content with full TLS security, TOFU certificate validation, and 
 **Response Types:**
 
 - **GeminiGemtextResult**: For gemtext content (text/gemini)
-  - Parsed gemtext document with structured lines, links, and headings
+  - Parsed gemtext document with structured lines and links (headings are line entries)
 - **GeminiSuccessResult**: For other text and binary content
   - Raw content with MIME type information
 - **GeminiInputResult**: For input requests (status 10-11)

--- a/docs/ai-assistant-guide.md
+++ b/docs/ai-assistant-guide.md
@@ -52,19 +52,19 @@ result = gopher_fetch(url)
 if result["kind"] == "menu":
     # Handle menu items
     for item in result["items"]:
-        print(f"{item['type']}: {item['display_text']}")
+        print(f"{item['type']}: {item['title']}")
 
 elif result["kind"] == "text":
     # Handle text content
-    print(result["content"])
+    print(result["text"])
 
 elif result["kind"] == "binary":
     # Handle binary file metadata
-    print(f"Binary file: {result['description']}")
+    print(f"Binary file: {result['note']}")
 
 elif result["kind"] == "error":
     # Handle errors
-    print(f"Error: {result['error']}")
+    print(f"Error: {result['error']['message']}")
 ```
 
 ### Gopher Item Types
@@ -112,34 +112,35 @@ if result["kind"] == "gemtext":
     doc = result["document"]
     for line in doc["lines"]:
         if line["type"] == "heading1":
-            print(f"# {line['text']}")
+            print(f"# {line['heading']['text']}")
         elif line["type"] == "link":
-            print(f"Link: {line['text']} -> {line['url']}")
+            print(f"Link: {line['link']['text']} -> {line['link']['url']}")
         elif line["type"] == "text":
-            print(line["text"])
+            print(line["content"])
 
 elif result["kind"] == "success":
     # Handle other content types
     mime = result["mime_type"]
-    if mime["is_text"]:
+    if mime["type"] == "text":
         print(result["content"])
     else:
-        print(f"Binary content: {mime['full_type']}")
+        print(f"Binary content: {mime['type']}/{mime['subtype']}")
 
 elif result["kind"] == "input":
     # Handle input requests
     print(f"Input required: {result['prompt']}")
-    # Note: In MCP context, you cannot provide input
+    # Answer with: gemini_fetch(url, input="...")
 
 elif result["kind"] == "redirect":
     # Handle redirects
-    new_url = result["url"]
+    new_url = result["new_url"]
     print(f"Redirected to: {new_url}")
     # Follow redirect if appropriate
 
 elif result["kind"] == "error":
     # Handle errors
-    print(f"Error {result['status']}: {result['message']}")
+    err = result["error"]
+    print(f"Error {err['status']}: {err['message']}")
 ```
 
 ### Gemini Status Codes
@@ -220,18 +221,19 @@ result = gopher_fetch("gopher://gopher.floodgap.com/1/")
 if result["kind"] == "menu":
     for item in result["items"]:
         if item["type"] == "1":  # Submenu
-            print(f"Directory: {item['display_text']}")
+            print(f"Directory: {item['title']}")
         elif item["type"] == "0":  # Text file
-            print(f"Text file: {item['display_text']}")
+            print(f"Text file: {item['title']}")
 
 # Browse Gemini content
 result = gemini_fetch("gemini://geminiprotocol.net/")
 if result["kind"] == "gemtext":
     # Show headings and links
-    for heading in result["document"]["headings"]:
-        print(f"Section: {heading['text']}")
+    headings = [ln for ln in result["document"]["lines"] if ln["type"].startswith("heading")]
+    for heading in headings:
+        print(f"Section: {heading['heading']['text']}")
     for link in result["document"]["links"]:
-        print(f"Link: {link['text']} -> {link['url']}")
+        print(f"Link: {link.get('text')} -> {link['url']}")
 ```
 
 ### Search Operations
@@ -253,7 +255,8 @@ if result["kind"] == "menu":
 result = gemini_fetch("gemini://example.org/article")
 if result["kind"] == "gemtext":
     doc = result["document"]
-    print(f"Article has {len(doc['headings'])} sections")
+    headings = [ln for ln in doc["lines"] if ln["type"].startswith("heading")]
+    print(f"Article has {len(headings)} sections")
     print(f"Contains {len(doc['links'])} links")
     print(f"Total lines: {len(doc['lines'])}")
 ```
@@ -280,12 +283,10 @@ def safe_fetch(url, protocol="auto"):
     except Exception as e:
         return {
             "kind": "error",
-            "error": str(e),
-            "suggestions": [
-                "Check if the URL is correct",
-                "Verify the server is online",
-                "Try again later if it's a temporary issue"
-            ]
+            "error": {
+                "code": "FETCH_FAILED",
+                "message": str(e),
+            },
         }
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -34,7 +34,7 @@ result = await gopher_fetch("gopher://gopher.floodgap.com/1/")
 if result["kind"] == "menu":
     print(f"Found {len(result['items'])} menu items")
     for item in result["items"]:
-        print(f"  {item['display_text']} ({item['type']})")
+        print(f"  {item['title']} ({item['type']})")
 ```
 
 ##### Fetching a Text File
@@ -44,8 +44,8 @@ if result["kind"] == "menu":
 result = await gopher_fetch("gopher://gopher.floodgap.com/0/gopher/tech/history.txt")
 
 if result["kind"] == "text":
-    print(f"Content ({result['size']} bytes):")
-    print(result["content"])
+    print(f"Content ({result['bytes']} bytes):")
+    print(result["text"])
 ```
 
 ##### Performing a Gopher Search
@@ -65,10 +65,9 @@ if result["kind"] == "menu":
 result = await gopher_fetch("gopher://gopher.floodgap.com/9/file.zip")
 
 if result["kind"] == "binary":
-    print(f"Binary file: {result['description']}")
-    print(f"Type: {result['item_type']}")
-    if result.get("size"):
-        print(f"Size: {result['size']} bytes")
+    print(f"Binary file: {result['note']}")
+    print(f"Type: {result['mime_type']}")
+    print(f"Size: {result['bytes']} bytes")
 ```
 
 ##### Error Handling
@@ -78,13 +77,7 @@ if result["kind"] == "binary":
 result = await gopher_fetch("gopher://invalid.example.com/1/")
 
 if result["kind"] == "error":
-    print(f"Error: {result['error']}")
-    if result.get("details"):
-        print(f"Details: {result['details']}")
-    if result.get("suggestions"):
-        print("Suggestions:")
-        for suggestion in result["suggestions"]:
-            print(f"  - {suggestion}")
+    print(f"Error [{result['error']['code']}]: {result['error']['message']}")
 ```
 
 #### Response Types
@@ -125,13 +118,15 @@ from gopher_mcp.server import gemini_fetch
 result = await gemini_fetch("gemini://geminiprotocol.net/")
 
 if result["kind"] == "gemtext":
-    print(f"Document has {len(result['document']['lines'])} lines")
+    lines = result["document"]["lines"]
+    headings = [ln for ln in lines if ln["type"].startswith("heading")]
+    print(f"Document has {len(lines)} lines")
     print(f"Found {len(result['document']['links'])} links")
-    print(f"Found {len(result['document']['headings'])} headings")
+    print(f"Found {len(headings)} headings")
 
     # Print all headings
-    for heading in result["document"]["headings"]:
-        print(f"{'#' * heading['level']} {heading['text']}")
+    for heading in headings:
+        print(f"{'#' * heading['level']} {heading['heading']['text']}")
 ```
 
 ##### Fetching Plain Text
@@ -141,8 +136,9 @@ if result["kind"] == "gemtext":
 result = await gemini_fetch("gemini://example.com/document.txt")
 
 if result["kind"] == "success":
-    print(f"MIME type: {result['mime_type']['full_type']}")
-    if result["mime_type"]["is_text"]:
+    mime = result["mime_type"]
+    print(f"MIME type: {mime['type']}/{mime['subtype']}")
+    if mime["type"] == "text":
         print(f"Content:\n{result['content']}")
 ```
 
@@ -153,11 +149,11 @@ if result["kind"] == "success":
 result = await gemini_fetch("gemini://example.com/old-page")
 
 if result["kind"] == "redirect":
-    print(f"Redirected to: {result['url']}")
+    print(f"Redirected to: {result['new_url']}")
     print(f"Permanent: {result['permanent']}")
 
     # Follow the redirect
-    new_result = await gemini_fetch(result["url"])
+    new_result = await gemini_fetch(result["new_url"])
 ```
 
 ##### Handling Input Requests
@@ -170,10 +166,8 @@ if result["kind"] == "input":
     print(f"Server requests input: {result['prompt']}")
     print(f"Sensitive: {result['sensitive']}")
 
-    # Provide input by appending to URL
-    user_input = "search query"
-    new_url = f"{result['request_info']['url']}?{user_input}"
-    new_result = await gemini_fetch(new_url)
+    # Answer the prompt with the gemini_fetch input parameter
+    new_result = await gemini_fetch("gemini://example.com/search", input="search query")
 ```
 
 ##### Handling Certificate Requests
@@ -195,14 +189,13 @@ if result["kind"] == "certificate":
 result = await gemini_fetch("gemini://example.com/notfound")
 
 if result["kind"] == "error":
-    print(f"Error {result['status']}: {result['message']}")
+    err = result["error"]
+    print(f"Error {err['status']}: {err['message']}")
 
-    if result["is_temporary"]:
+    if err["temporary"]:
         print("This is a temporary error - retry may succeed")
-    elif result["is_server_error"]:
-        print("Server error - contact server administrator")
-    elif result["is_client_error"]:
-        print("Client error - check your request")
+    else:
+        print("Permanent error - do not retry")
 ```
 
 ##### Working with Links
@@ -216,7 +209,6 @@ if result["kind"] == "gemtext":
         print(f"Link: {link['url']}")
         if link.get("text"):
             print(f"  Text: {link['text']}")
-        print(f"  Line: {link['line_number']}")
 ```
 
 #### Response Types
@@ -388,7 +380,7 @@ Common Gopher errors and how to handle them:
 # GOPHER_TIMEOUT_SECONDS=60
 
 result = await gopher_fetch("gopher://slow-server.example.com/1/")
-if result["kind"] == "error" and "timeout" in result["error"].lower():
+if result["kind"] == "error" and "timeout" in result["error"]["message"].lower():
     print("Server is slow or unreachable - try again later")
 ```
 
@@ -418,10 +410,8 @@ result = await gopher_fetch(valid_url)
 
 ```python
 result = await gopher_fetch("gopher://example.com/X/unknown")
-if result["kind"] == "error" and "unsupported" in result["error"].lower():
+if result["kind"] == "error" and "unsupported" in result["error"]["message"].lower():
     print("This content type is not supported")
-    if result.get("suggestions"):
-        print("Try:", result["suggestions"])
 ```
 
 #### Content Too Large
@@ -437,7 +427,7 @@ if result["kind"] == "error" and "unsupported" in result["error"].lower():
 # GOPHER_MAX_RESPONSE_SIZE=2097152
 
 result = await gopher_fetch("gopher://example.com/0/large-file.txt")
-if result["kind"] == "error" and "size" in result["error"].lower():
+if result["kind"] == "error" and "size" in result["error"]["message"].lower():
     print("File is too large - increase GOPHER_MAX_RESPONSE_SIZE")
 ```
 
@@ -534,22 +524,26 @@ if result["kind"] == "error" and "allowed" in result["error"]["message"].lower()
 All error responses include:
 
 ```python
+# Gopher error
 {
     "kind": "error",
     "error": {
+        "code": "ERROR_CODE",  # Machine-readable error code
         "message": "Human-readable error message",
-        "type": "ErrorType",  # Exception class name
-        "details": "Additional technical details"
     },
-    "suggestions": [  # Optional troubleshooting suggestions
-        "Try increasing timeout",
-        "Check server availability"
-    ],
-    "request_info": {
-        "url": "original://request/url",
-        "timestamp": 1234567890,
-        "protocol": "gopher" or "gemini"
-    }
+    "request_info": { ... },  # Free-form request metadata
+}
+
+# Gemini error (also carries status / temporary)
+{
+    "kind": "error",
+    "error": {
+        "code": "TEMPORARY_ERROR",  # or "PERMANENT_ERROR", etc.
+        "message": "Human-readable error message",
+        "status": 51,  # Gemini status code
+        "temporary": False,
+    },
+    "request_info": { ... },
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gopher-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "A cross-platform Model Context Protocol (MCP) server for browsing Gopher and Gemini resources"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_serialization_contract.py
+++ b/tests/test_serialization_contract.py
@@ -1,0 +1,84 @@
+"""Serialization-contract tests for the public result models.
+
+The MCP tools return ``model_dump()`` dicts (field names, no aliases), and the
+documentation examples access those dicts by key. These tests pin the serialized
+key set of every public result/content model so that a field rename or addition
+fails loudly here — a reminder to update the docs (and any consumers) alongside
+the code. If you intentionally change a model's shape, update the expected set
+below and the corresponding documentation/examples.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gopher_mcp import models
+
+# Expected serialized keys = declared fields + computed fields (what model_dump()
+# emits without ``by_alias=True``, which is how the tools serialize results).
+EXPECTED_KEYS: dict[str, set[str]] = {
+    # Gopher result models
+    "GopherMenuItem": {"type", "title", "selector", "host", "port", "next_url"},
+    "MenuResult": {"kind", "items", "request_info"},
+    "TextResult": {"kind", "charset", "bytes", "text", "truncated", "request_info"},
+    "BinaryResult": {"kind", "bytes", "mime_type", "note", "request_info"},
+    "ErrorResult": {"kind", "error", "request_info"},
+    # Gemini result models
+    "GeminiSuccessResult": {
+        "kind",
+        "mime_type",
+        "content",
+        "size",
+        "truncated",
+        "request_info",
+    },
+    "GeminiInputResult": {"kind", "prompt", "sensitive", "request_info"},
+    "GeminiRedirectResult": {"kind", "new_url", "permanent", "request_info"},
+    "GeminiErrorResult": {"kind", "error", "request_info"},
+    "GeminiCertificateResult": {
+        "kind",
+        "message",
+        "status",
+        "required",
+        "request_info",
+    },
+    "GeminiGemtextResult": {
+        "kind",
+        "document",
+        "raw_content",
+        "charset",
+        "lang",
+        "size",
+        "request_info",
+    },
+    # Gemtext content models
+    "GemtextDocument": {"lines", "links"},
+    "GemtextLine": {
+        "type",
+        "content",
+        "link",
+        "level",
+        "alt_text",
+        "heading",
+        "list_item",
+        "quote",
+        "preformat",
+    },
+    "GemtextLink": {"url", "text"},
+    "GemtextHeading": {"level", "text", "raw_content"},
+    # MIME type model (nested under GeminiSuccessResult.mime_type)
+    "GeminiMimeType": {"type", "subtype", "charset", "lang"},
+}
+
+
+@pytest.mark.parametrize("model_name", sorted(EXPECTED_KEYS))
+def test_serialized_keys_match_contract(model_name: str) -> None:
+    """The model's serialized key set matches the documented contract."""
+    model = getattr(models, model_name)
+    serialized = set(model.model_fields) | set(model.model_computed_fields)
+    assert serialized == EXPECTED_KEYS[model_name], (
+        f"{model_name} serialized keys changed: "
+        f"unexpected={serialized - EXPECTED_KEYS[model_name]}, "
+        f"missing={EXPECTED_KEYS[model_name] - serialized}. "
+        "Update EXPECTED_KEYS and the docs/examples that reference these fields."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -752,7 +752,7 @@ wheels = [
 
 [[package]]
 name = "gopher-mcp"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## 📝 Description

Fixes the documentation code examples to match the **real** tool output, adds a
contract test so the response shape can't silently drift again, and cuts the
**0.4.1** release.

### The bug

The tools return `model_dump()` dicts (field names, no aliases), but the
hand-written examples accessed keys that don't exist — they'd raise `KeyError`
if a user ran them. Verified each against live tool output. Examples:

| Example used (wrong) | Real key |
|---|---|
| `item["display_text"]` | `item["title"]` |
| `result["content"]` / `result["size"]` (Gopher text) | `result["text"]` / `result["bytes"]` |
| `result["description"]` / `result["item_type"]` (binary) | `result["note"]` / `result["mime_type"]` |
| `result["error"]` as a string | nested `result["error"]["message"]` / `["code"]` |
| `result["document"]["headings"]` | derive from `document["lines"]` (no `headings` key) |
| `result["mime_type"]["full_type"]` | `f'{mt["type"]}/{mt["subtype"]}'` (no `full_type`) |
| `result["url"]` (redirect) | `result["new_url"]` |
| `result["status"]` / `result["is_temporary"]` (Gemini error) | `result["error"]["status"]` / `["temporary"]` |

Fixed across `api-reference.md`, `ai-assistant-guide.md`, and `README.md`. The
Gemini input example now uses the `input=` parameter instead of manual URL
building.

### The guardrail

New `tests/test_serialization_contract.py` pins every public result model's
`model_dump()` key set. A future field rename/add now fails this test, forcing
the docs (and any consumers) to be updated alongside the code — complementing the
auto-generated model reference added in #50.

### Release 0.4.1

- Bumped `pyproject.toml` + `uv.lock` to 0.4.1.
- Finalized the `[0.4.1]` CHANGELOG section (this PR's fixes/test plus the
  documentation overhaul from #49/#50) and refreshed the compare links.

## 🧪 Type of Change

- [x] 🐛 Bug fix (documentation examples that would error)
- [x] 🧪 Test improvement
- [x] 📚 Documentation update

## 🧪 Testing

```bash
uv run pytest                                       # 647 passed, 93.94% coverage
uv run --extra docs mkdocs build --clean --strict   # clean
uv run pre-commit run --all-files                   # all hooks pass
```

Additionally executed every fixed access pattern (menu→`title`, text→`text`/`bytes`,
gemtext→`lines`/`content`/heading-from-lines, links→`url`/`text`, errors→nested
`error.*`, success→`mime_type` type/subtype, redirect→`new_url`) against live
Gopher/Gemini servers — all succeed with no `KeyError`.

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation

## 📝 Additional Notes

This is the release PR for **0.4.1**. After merge, tag `v0.4.1` from `main` to
trigger the publish workflow (which still pauses on the `pypi` environment for
manual approval).
