### PR TITLE
chore(release): 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-09
+
 ### Security
 
 - Move the Gemini TLS transport to native asyncio (`asyncio.open_connection`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gopher-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "A cross-platform Model Context Protocol (MCP) server for browsing Gopher and Gemini resources"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.cameronrye/gopher-mcp",
   "description": "MCP server for browsing Gopher and Gemini protocol resources safely, with SSRF protection, TLS/TOFU, and structured JSON output.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "repository": {
     "url": "https://github.com/cameronrye/gopher-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registry_type": "pypi",
       "registry_base_url": "https://pypi.org",
       "identifier": "gopher-mcp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ wheels = [
 
 [[package]]
 name = "gopher-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Cuts **0.4.2**, releasing the hardening from #52 and the refactors from #53. Version bumped in `pyproject.toml`, `server.json` (both fields), and `uv.lock`; the `[Unreleased]` changelog section is promoted to `[0.4.2]`. Package builds and `twine check` passes.

### What's in 0.4.2

**Security**
- Gemini TLS moved to native asyncio — slow-loris/stalled peers are now cut off at the deadline instead of parking worker threads; removes the thread pool shared with DNS resolution (whole-server DoS vector).
- Status-11 sensitive input no longer leaks to logs, `requestInfo`, or the cache key.
- TOFU fails closed on not-yet-valid certs by default.
- Empty/self-referential Gemini redirects rejected (`INVALID_REDIRECT`).

**Added**
- `GOPHER_MAX_MENU_ITEMS` cap; optional `GOPHER_ALLOWED_PORTS` / `GEMINI_ALLOWED_PORTS` allowlist.

**Changed**
- `max_rendered_chars` now applies to `text/gemini` (gemtext + menu results carry a `truncated` flag); dropped the over-strict TLS 1.2 cipher list; de-duplicated the batch-fetch tools.

**Removed**
- Unused `http`/`aiohttp` extra, never-read `development_mode`, `create_tls_client`, and the dead gemtext helper properties.

**Fixed**
- LLM-facing `next_url` field-name drift; `server.json` version drift (+ a release-workflow guard); placeholder author/maintainer/copyright metadata; overpromising connection-pooling docs.

Once merged, the final step is tagging `v0.4.2`, which triggers the trusted-publishing workflow to PyPI.
