### PR TITLE
Low-severity review follow-ups: protocol correctness + supply-chain hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Keep the Docker build context (and image) small and free of local/secret
+# state. The Dockerfile builds a wheel from `COPY . .`, so anything not needed
+# to build that wheel should be excluded -- especially .git and any local env.
+
+# Version control
+.git/
+.gitignore
+.github/
+
+# Local environment / secrets
+.env
+*.env
+!config/example.env
+.venv/
+venv/
+env/
+
+# Python build/test artifacts and caches
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+coverage.xml
+coverage.json
+*-report.json
+
+# Docs site build
+site/
+
+# Editor / OS / tooling
+.vscode/
+.idea/
+.claude/
+.DS_Store
+
+# Docker
+Dockerfile
+.dockerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -64,7 +64,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -124,7 +124,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -154,7 +154,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -190,7 +190,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -247,7 +247,7 @@ jobs:
           echo "Generated release notes for version $VERSION"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: v${{ needs.validate-release.outputs.version }}
           name: Release v${{ needs.validate-release.outputs.version }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- The Gopher menu parser now stops at the RFC 1436 `.` terminator, so data a
+  server appends after the terminator is no longer parsed into navigable items.
+
+### Fixed
+
+- A Gemini status-20 response with an absent/unparseable MIME now defaults to
+  `text/gemini` (per the spec) instead of being content-sniffed and
+  misclassified as binary; genuine binary content is still detected by
+  signature.
+- Client-certificate scope lookup now normalizes the host (case / trailing
+  dot), matching TOFU and the SSRF/allowlist paths, so a host variant no longer
+  silently misses a stored client identity.
+- `GopherURL` rejects an empty host at the model boundary (symmetry with
+  `GeminiURL`).
+
+### Changed
+
+- Supply-chain hygiene: added a `.dockerignore` (keeps `.git`/local `.env` out
+  of the Docker build context), SHA-pinned the third-party GitHub Actions, and
+  raised the `cryptography` floor to `>=43.0.0`.
+
 ## [0.4.2] - 2026-06-09
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "structlog>=23.2.0",
     "anyio>=4.0.0",
-    "cryptography>=41.0.0",
+    # Floor kept reasonably recent: a fresh `pip install` resolves the newest
+    # cryptography anyway, but this refuses to run against a years-old version
+    # (with known CVEs) that an end user might already have pinned.
+    "cryptography>=43.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/gopher_mcp/client_certs.py
+++ b/src/gopher_mcp/client_certs.py
@@ -53,8 +53,15 @@ class ClientCertificateManager:
         self._load_registry()
 
     def _get_cert_key(self, host: str, port: int, path: str) -> str:
-        """Get storage key for certificate scope."""
-        return f"{host}:{port}{path}"
+        """Get storage key for certificate scope.
+
+        Normalize the host (lowercase, strip IPv6 brackets and a trailing dot)
+        so a case/trailing-dot variant resolves to the same stored identity,
+        matching the TOFU and SSRF/allowlist host handling.
+        """
+        from .ssrf import normalize_host
+
+        return f"{normalize_host(host)}:{port}{path}"
 
     def _load_registry(self) -> None:
         """Load certificate registry from storage.
@@ -292,12 +299,15 @@ class ClientCertificateManager:
                 return str(cert_path), str(key_path)
 
         # Try to find a certificate for a parent path
+        from .ssrf import normalize_host
+
+        norm_host = normalize_host(host)
         best_match = None
         best_path_len = 0
 
         for stored_cert in self._certificates.values():
             if (
-                stored_cert.host == host
+                normalize_host(stored_cert.host) == norm_host
                 and stored_cert.port == port
                 and path.startswith(stored_cert.path)
                 and len(stored_cert.path) > best_path_len

--- a/src/gopher_mcp/models.py
+++ b/src/gopher_mcp/models.py
@@ -166,6 +166,14 @@ class GopherURL(BaseModel):
             raise ValueError("Gopher type must be a single character")
         return v
 
+    @field_validator("host")
+    @classmethod
+    def validate_host(cls, v: str) -> str:
+        """Validate hostname is not empty (mirrors GeminiURL)."""
+        if not v.strip():
+            raise ValueError("Host cannot be empty")
+        return v.strip()
+
 
 class CacheEntry(_BaseCacheEntry[GopherFetchResponse]):
     """Model for Gopher cache entries."""

--- a/src/gopher_mcp/utils.py
+++ b/src/gopher_mcp/utils.py
@@ -266,6 +266,10 @@ def parse_gopher_menu(content: str) -> list[GopherMenuItem]:
     # breaks on VT/FF/NEL and could split a display string mid-field.
     normalized = content.replace("\r\n", "\n").replace("\r", "\n")
     for line in normalized.split("\n"):
+        # RFC 1436: a lone '.' terminates the menu. Stop here so data a server
+        # places AFTER the terminator is never parsed into navigable items.
+        if line == ".":
+            break
         item = parse_menu_line(line)
         if item:
             items.append(item)

--- a/src/gopher_mcp/utils.py
+++ b/src/gopher_mcp/utils.py
@@ -1414,16 +1414,20 @@ def _process_success_response(
                 raise ValueError(f"Invalid MIME type: {meta}")
 
     except ValueError:
-        # For binary content, try to detect MIME type from content
-        if body and len(body) > 0:
-            detected_type = detect_binary_mime_type(body)
+        # Per the Gemini spec, an absent/unparseable MIME defaults to text/gemini.
+        # Sniff the body so genuinely binary content served with a bad MIME is
+        # still detected by signature -- but a non-match yields the octet-stream
+        # fallback, which must NOT misclassify textual/gemtext content as binary;
+        # in that case fall back to the text/gemini default.
+        detected_type = (
+            detect_binary_mime_type(body) if body else "application/octet-stream"
+        )
+        if detected_type != "application/octet-stream":
             try:
                 mime_type = parse_gemini_mime_type(detected_type)
             except ValueError:
-                # Fallback to default
                 mime_type = get_default_gemini_mime_type()
         else:
-            # For empty body, fallback to default
             mime_type = get_default_gemini_mime_type()
 
     size = len(body)

--- a/tests/test_client_certs.py
+++ b/tests/test_client_certs.py
@@ -539,3 +539,17 @@ class TestCertificateFilePermissions:
 
             dir_mode = manager.storage_path.stat().st_mode & 0o777
             assert dir_mode == 0o700, f"storage dir mode is {oct(dir_mode)}, want 0o700"
+
+
+class TestClientCertScopeNormalization:
+    """Client-cert scope lookup must normalize the host (case/trailing-dot), so
+    a stored identity isn't silently missed -- matching TOFU and the SSRF/
+    allowlist paths, which all normalize the host."""
+
+    def test_get_cert_key_normalizes_host(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(ClientCertificateManager, "_load_registry"):
+                mgr = ClientCertificateManager(tmp)
+            assert mgr._get_cert_key("Example.COM.", 1965, "/") == mgr._get_cert_key(
+                "example.com", 1965, "/"
+            )

--- a/tests/test_gemini_status.py
+++ b/tests/test_gemini_status.py
@@ -424,6 +424,31 @@ class TestProcessGeminiResponse:
         # `size` still reports the full original byte length.
         assert result.size == len(body.encode("utf-8"))
 
+    def test_success_malformed_mime_with_text_body_defaults_to_gemtext(self):
+        """A status-20 with an unparseable MIME and a textual body must default
+        to text/gemini (the Gemini spec default), not be content-sniffed into
+        application/octet-stream and returned as binary."""
+        body = "# Heading\n=> /x A link\nsome text"
+        response = GeminiResponse(
+            status=GeminiStatusCode.SUCCESS,
+            meta="garbage-no-slash",
+            body=body.encode("utf-8"),
+        )
+        result = process_gemini_response(response, "gemini://example.org/")
+        assert isinstance(result, GeminiGemtextResult)
+        assert result.raw_content == body
+
+    def test_success_malformed_mime_with_binary_body_still_detected(self):
+        """Real binary content served with a bad MIME is still detected by its
+        signature (octet-stream fallback only applies when nothing matched)."""
+        png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        response = GeminiResponse(
+            status=GeminiStatusCode.SUCCESS, meta="garbage-no-slash", body=png
+        )
+        result = process_gemini_response(response, "gemini://example.org/")
+        assert isinstance(result, GeminiSuccessResult)
+        assert result.mime_type.full_type == "image/png"
+
     def test_success_binary_response(self):
         """Test success binary response processing."""
         binary_data = b"\x89PNG\r\n\x1a\n"  # PNG header
@@ -651,15 +676,15 @@ class TestProcessGeminiResponse:
         assert result.size == 0
 
     def test_success_response_invalid_mime_type(self):
-        """Test success response with invalid MIME type."""
+        """An invalid MIME with a textual body defaults to text/gemini (the
+        Gemini spec default), not content-sniffed binary."""
         response = GeminiResponse(
             status=GeminiStatusCode.SUCCESS, meta="invalid-mime-type", body=b"content"
         )
 
-        # Should fallback to binary detection instead of raising error
         result = process_gemini_response(response, "gemini://example.org/")
-        assert isinstance(result, GeminiSuccessResult)
-        assert result.mime_type.full_type == "application/octet-stream"
+        assert isinstance(result, GeminiGemtextResult)
+        assert result.raw_content == "content"
 
     def test_success_response_decode_error(self):
         """Test success response with decode error."""
@@ -734,7 +759,7 @@ class TestProcessGeminiResponse:
         assert result.content == png_data
 
     def test_success_response_invalid_mime_fallback(self):
-        """Test success response with invalid MIME type fallback."""
+        """An invalid MIME with non-binary content defaults to text/gemini."""
         response = GeminiResponse(
             status=GeminiStatusCode.SUCCESS,
             meta="invalid/mime/type",
@@ -743,10 +768,8 @@ class TestProcessGeminiResponse:
 
         result = process_gemini_response(response, "gemini://example.org/")
 
-        assert isinstance(result, GeminiSuccessResult)
-        # Should fallback to binary detection since text content doesn't match known binary formats
-        assert result.mime_type.full_type == "application/octet-stream"
-        assert result.content == b"Hello, world!"  # Binary content stays as bytes
+        assert isinstance(result, GeminiGemtextResult)
+        assert result.raw_content == "Hello, world!"
 
     def test_success_response_invalid_mime_empty_body_fallback(self):
         """Test success response with invalid MIME type and empty body fallback."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -199,6 +199,14 @@ class TestGopherURL:
         assert url.gopher_type == "7"
         assert url.search == "test query"
 
+    def test_empty_host_rejected(self):
+        """An empty/whitespace host must be rejected at the model boundary, the
+        same as GeminiURL (otherwise an empty host is only caught later)."""
+        with pytest.raises(ValidationError, match="Host cannot be empty"):
+            GopherURL(host="", port=70)
+        with pytest.raises(ValidationError, match="Host cannot be empty"):
+            GopherURL(host="   ", port=70)
+
     def test_gopher_type_validation(self):
         """Test Gopher type validation."""
         with pytest.raises(ValidationError) as exc_info:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -260,6 +260,20 @@ invalid line
         assert result[0].title == "Valid"
         assert result[1].title == "Another Valid"
 
+    def test_stops_at_terminator(self):
+        """RFC 1436: the lone '.' line terminates the menu. Anything after it
+        (which a server could append past the terminator) must NOT be parsed
+        into menu items the model would be told it can navigate to."""
+        content = (
+            "1Before\t/before\texample.com\t70\r\n"
+            ".\r\n"
+            "1AfterTerminator\t/evil\tattacker.example\t70\r\n"
+        )
+        result = parse_gopher_menu(content)
+
+        assert len(result) == 1
+        assert result[0].title == "Before"
+
 
 class TestSanitizeSelector:
     """Test sanitize_selector function."""

--- a/uv.lock
+++ b/uv.lock
@@ -556,7 +556,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.5" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.3.0" },
-    { name = "cryptography", specifier = ">=41.0.0" },
+    { name = "cryptography", specifier = ">=43.0.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-autorefs", marker = "extra == 'docs'", specifier = ">=0.5.0" },


### PR DESCRIPTION
The LOW-severity correctness + hygiene findings from the end-to-end review, each a focused, TDD'd commit. These land under `[Unreleased]` for a future 0.4.3. Full gate: whole-repo `ruff` clean, `mypy` clean, `bandit` clean, **664 tests pass at 93.5%**. Independent review of the diff found no blocking issues.

## Correctness

- **`fix(gopher): stop menu parsing at the RFC 1436 '.' terminator`** — `parse_gopher_menu` dropped the lone `.` line but kept parsing what followed, so a server could append items past the terminator that the model would be told it can navigate to. Now breaks at the terminator.
- **`fix(gemini): default unparseable status-20 MIME to text/gemini, not binary`** — an absent/unparseable MIME was content-sniffed, and any non-match returned the `application/octet-stream` fallback — misclassifying gemtext (the dominant type) as binary and base64-encoding it. Now defaults to `text/gemini` per spec; genuine binary is still detected by signature.
- **`fix(gemini): normalize host in client-cert scope lookup`** — keyed/matched on the raw host while TOFU + SSRF + allowlist all normalize it, so a case/trailing-dot variant silently sent no client cert. Now normalizes host in `_get_cert_key` and the parent-path scan.
- **`fix(gopher): reject empty host in GopherURL`** — `GeminiURL` rejected an empty host at the model boundary but `GopherURL` didn't; added the matching validator.

## Supply-chain hygiene

- **`chore: supply-chain hygiene`** — added a `.dockerignore` (the Dockerfile builds a wheel from `COPY . .`, which otherwise ships `.git`/local `.env` into the build context); SHA-pinned the third-party actions (`astral-sh/setup-uv`, `softprops/action-gh-release`) with version comments, matching the already-pinned `pypa/gh-action-pypi-publish`; raised the `cryptography` floor to `>=43.0.0`.

## Notes / deferred

- **mypy scope** (extend to `scripts/`+`task.py`) was deferred: `scripts/` currently has ~34 type errors (missing annotations), so extending the gate is a separate chore with low payoff (scripts aren't shipped).
- **Client-cert migration:** pre-existing registry entries keyed by a non-normalized host become benign orphans — they're still served via the parent-path scan and rewritten under the normalized key on the next `generate_certificate`. No action needed.
- Lower-value LOW items intentionally left (request coalescing, Gemini multi-address fallback, rate-limiter unbounded-state-when-disabled, type-7 empty-query collapse, heading 4+ markers) — marginal payoff / higher churn; can revisit if desired.
