### PR TITLE
Review follow-ups: protocol/security correctness fixes from end-to-end review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Gopher menu parser now stops at the RFC 1436 `.` terminator, so data a
   server appends after the terminator is no longer parsed into navigable items.
+  The terminator check now also tolerates trailing whitespace (a `". "` line),
+  so a non-conformant server can't slip later items past what reads as the end.
+- Client certificates are now scoped on path-segment boundaries: a certificate
+  for `/api` is no longer sent to a sibling path such as `/api_admin`, closing
+  an identity-scope leak.
+- A blocked SSRF target no longer echoes the resolved internal IP back to the
+  caller (it is logged server-side only), so the error can't be used to map
+  internal network topology.
+- The Gemini request send is now bounded by the request deadline (the receive
+  side already was), so a peer that completes the handshake then stops reading
+  can't pin the request until the OS TCP timeout.
 
 ### Fixed
 
@@ -21,10 +32,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client-certificate scope lookup now normalizes the host (case / trailing
   dot), matching TOFU and the SSRF/allowlist paths, so a host variant no longer
   silently misses a stored client identity.
+- The client-certificate common name is now parsed via the cryptography
+  library, so a CN containing an escaped comma is no longer truncated (which
+  made the certificate unfindable on disk and silently unusable).
+- IPv6 literal hosts are now bracketed in every constructed `gopher://` and
+  `gemini://` URL (menu `nextUrl`, the URL formatters, the Gemini request line
+  and the display/log helper), so the address colons no longer collide with the
+  port separator and break re-parsing.
+- A Gopher menu item with a numeric but out-of-range port (>65535) now degrades
+  to the default port 70 instead of failing validation and dropping the whole
+  item.
+- The Gopher client no longer caches error responses, so a transient failure is
+  no longer served stale for the cache TTL (matching the Gemini client).
+- Response cache keys are now case-insensitive in the hostname, so the same
+  resource requested with a different host case shares one cache entry.
 - `GopherURL` rejects an empty host at the model boundary (symmetry with
   `GeminiURL`).
 
 ### Changed
+
+- Documentation: corrected the API reference (fresh connection per request, no
+  pooling), removed the non-existent `GOPHER_HTTP_HOST`/`GOPHER_HTTP_PORT` env
+  vars (host/port are `--host`/`--port` CLI flags), and documented that the
+  HTTP transports are unauthenticated and the Docker image binds `0.0.0.0:8000`
+  by default.
 
 - Supply-chain hygiene: added a `.dockerignore` (keeps `.git`/local `.env` out
   of the Docker build context), SHA-pinned the third-party GitHub Actions, and

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -186,8 +186,12 @@ gopher://veronica.example.com/7/search%09python
 | `GOPHER_ALLOWED_HOSTS` | - | Comma-separated list of allowed hosts |
 | `GOPHER_MAX_SELECTOR_LENGTH` | 1024 | Maximum selector length |
 | `GOPHER_MAX_SEARCH_LENGTH` | 256 | Maximum search query length |
-| `GOPHER_HTTP_HOST` | localhost | HTTP server host |
-| `GOPHER_HTTP_PORT` | 8000 | HTTP server port |
+
+> **HTTP transport bind address.** The host/port for the `sse` and
+> `streamable-http` transports are **not** environment variables — they are set
+> with the `--host` / `--port` CLI flags (defaulting to FastMCP's
+> `127.0.0.1:8000`). See [Installation](installation.md) for the security
+> caveats when binding to a non-loopback address.
 
 ### Programmatic Configuration
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -589,7 +589,7 @@ Both protocols support intelligent caching:
 
 ### Connection Management
 
-- **Connection pooling**: Automatic connection reuse
+- **Fresh connection per request**: each fetch opens a new connection; there is no connection pooling or reuse
 - **Async/await**: Non-blocking I/O operations
 - **Streaming**: Memory-efficient content handling
 - **Resource cleanup**: Automatic connection cleanup

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -100,6 +100,18 @@ gopher-mcp --transport sse
 
 Then configure your MCP client to connect to the HTTP endpoint (default port varies by transport).
 
+!!! warning "Securing the HTTP transport"
+    The HTTP-based transports (`streamable-http`, `sse`) expose an
+    **unauthenticated** endpoint with no built-in TLS. By default they bind to
+    loopback (`127.0.0.1:8000`), which is safe for local use. Pass `--host` /
+    `--port` to change the bind address; binding to `0.0.0.0` exposes the server
+    on **all interfaces** and should only be done behind a trusted reverse proxy
+    that terminates TLS and handles authentication. Note that the provided
+    **Dockerfile** defaults its `CMD` to
+    `--transport streamable-http --host 0.0.0.0 --port 8000` so the container is
+    reachable out of the box — override it for production (bind `127.0.0.1`, or
+    use the `stdio` transport) unless it sits behind such a proxy.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/src/gopher_mcp/client_certs.py
+++ b/src/gopher_mcp/client_certs.py
@@ -20,6 +20,23 @@ from .utils import atomic_write_json, get_home_directory
 logger = structlog.get_logger(__name__)
 
 
+def _path_in_scope(path: str, scope: str) -> bool:
+    """Return True if ``path`` falls within a certificate's ``scope`` path.
+
+    Uses path-segment boundaries rather than a raw textual prefix: a cert
+    scoped to ``/api`` covers ``/api`` and ``/api/v1`` but NOT siblings like
+    ``/api_admin`` or ``/apixyz`` (which a naive ``startswith`` would wrongly
+    match, leaking the client identity outside its declared scope). A scope
+    already ending in ``/`` (notably the root ``/``) matches any path beneath
+    it.
+    """
+    if path == scope:
+        return True
+    if scope.endswith("/"):
+        return path.startswith(scope)
+    return path.startswith(scope + "/")
+
+
 class ClientCertificateError(Exception):
     """Exception raised for client certificate errors."""
 
@@ -309,7 +326,7 @@ class ClientCertificateManager:
             if (
                 normalize_host(stored_cert.host) == norm_host
                 and stored_cert.port == port
-                and path.startswith(stored_cert.path)
+                and _path_in_scope(path, stored_cert.path)
                 and len(stored_cert.path) > best_path_len
             ):
                 best_match = stored_cert
@@ -331,13 +348,30 @@ class ClientCertificateManager:
         return None
 
     def _extract_common_name(self, subject: str) -> str:
-        """Extract common name from certificate subject."""
-        # Parse RFC4514 string to extract CN
-        for raw_part in subject.split(","):
-            part = raw_part.strip()
-            if part.startswith("CN="):
-                return part[3:]
-        return "unknown"
+        """Extract the common name from an RFC 4514 certificate subject.
+
+        Parse via the cryptography library so escaped separators inside an
+        attribute value (RFC 4514 renders an embedded comma as ``\\,``) are
+        unescaped correctly. A naive split on commas would truncate such a CN,
+        and the filename derived from it would then no longer match the file on
+        disk -- silently disabling the certificate.
+        """
+        try:
+            name = x509.Name.from_rfc4514_string(subject)
+            attrs = name.get_attributes_for_oid(NameOID.COMMON_NAME)
+            if attrs:
+                return str(attrs[0].value)
+            return "unknown"
+        except ValueError:
+            # Not strict RFC 4514 (e.g. a legacy/hand-entered subject with a
+            # space after the comma). Fall back to a lenient split -- safe here
+            # because any value with an escaped comma IS valid RFC 4514 and was
+            # handled above, so this path never sees an escape to mangle.
+            for raw_part in subject.split(","):
+                part = raw_part.strip()
+                if part.startswith("CN="):
+                    return part[3:]
+            return "unknown"
 
     def list_certificates(self) -> list[GeminiCertificateInfo]:
         """List all stored certificates.

--- a/src/gopher_mcp/gemini_client.py
+++ b/src/gopher_mcp/gemini_client.py
@@ -27,6 +27,7 @@ from .tofu import (
 )
 from .utils import (
     bracket_host,
+    normalize_cache_key,
     parse_gemini_response,
     parse_gemini_url,
     process_gemini_response,
@@ -188,9 +189,13 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
             # Validate security constraints
             self._validate_security(parsed_url)
 
+            # Canonical cache key (case-insensitive host) so requests differing
+            # only in host case share one entry instead of duplicating.
+            cache_key = normalize_cache_key(url)
+
             # Check cache first
             if self.cache_enabled:
-                cached_response = self._get_cached_response(url)
+                cached_response = self._get_cached_response(cache_key)
                 if cached_response:
                     # Log without the query string: a status-10/11 answer (which
                     # the caller percent-encodes into the query) may be a secret.
@@ -247,7 +252,7 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
                     "certificate",
                 )
             ):
-                self._cache_response(url, response)
+                self._cache_response(cache_key, response)
 
             # Host/port/path are request metadata; keep them at DEBUG so default
             # INFO logs don't record every browsed resource. The query is NOT

--- a/src/gopher_mcp/gemini_client.py
+++ b/src/gopher_mcp/gemini_client.py
@@ -484,8 +484,15 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
 
             request_data = f"{request_url}\r\n".encode()
 
-            # Send request
-            await self.tls_client.send_data(connection, request_data)
+            # Send request under the request deadline. The payload is small, so
+            # this normally returns at once, but a peer that completes the
+            # handshake then never reads could otherwise block drain() until the
+            # OS TCP timeout -- bound it like the receive below (and like the
+            # Gopher transport, which wraps every I/O step).
+            await asyncio.wait_for(
+                self.tls_client.send_data(connection, request_data),
+                timeout=self.timeout_seconds,
+            )
 
             # Receive the response under an overall read deadline. With native
             # asyncio TLS the read is genuinely cancellable, so a slow-loris peer

--- a/src/gopher_mcp/gemini_client.py
+++ b/src/gopher_mcp/gemini_client.py
@@ -26,6 +26,7 @@ from .tofu import (
     TOFUValidationError,
 )
 from .utils import (
+    bracket_host,
     parse_gemini_response,
     parse_gemini_url,
     process_gemini_response,
@@ -49,7 +50,7 @@ def _safe_display_url(parsed_url: GeminiURL) -> str:
     reflected back to the caller. This mirrors the host/port/path-only logging
     used throughout this module.
     """
-    url = f"gemini://{parsed_url.host}"
+    url = f"gemini://{bracket_host(parsed_url.host)}"
     if parsed_url.port != 1965:
         url = f"{url}:{parsed_url.port}"
     return f"{url}{parsed_url.path}"
@@ -467,8 +468,9 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
                         warning=warning,
                     )
 
-            # Format Gemini request: URL + CRLF
-            request_url = f"gemini://{parsed_url.host}"
+            # Format Gemini request: URL + CRLF (bracket an IPv6 literal host
+            # per RFC 3986 so its colons aren't read as a port separator).
+            request_url = f"gemini://{bracket_host(parsed_url.host)}"
             if parsed_url.port != 1965:
                 request_url += f":{parsed_url.port}"
             request_url += parsed_url.path

--- a/src/gopher_mcp/gopher_client.py
+++ b/src/gopher_mcp/gopher_client.py
@@ -226,8 +226,10 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             if hasattr(response, "request_info"):
                 response.request_info.update(request_info)
 
-            # Cache the response
-            if self.cache_enabled:
+            # Cache the response, but skip errors: a transient failure would
+            # otherwise be served stale for the whole TTL. Mirrors the Gemini
+            # client, which excludes error/redirect/input/certificate results.
+            if self.cache_enabled and getattr(response, "kind", None) != "error":
                 self._cache_response(url, response)
 
             # Full URL/selector/search are request metadata; keep them at DEBUG

--- a/src/gopher_mcp/gopher_client.py
+++ b/src/gopher_mcp/gopher_client.py
@@ -23,6 +23,7 @@ from .ssrf import SSRFError, normalize_host, validate_target
 from .utils import (
     detect_binary_mime_type,
     gopher_type_category,
+    normalize_cache_key,
     parse_gopher_menu,
     parse_gopher_url,
     truncate_text,
@@ -196,9 +197,13 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             # Validate security constraints
             self._validate_security(parsed_url)
 
+            # Canonical cache key (case-insensitive host) so requests differing
+            # only in host case share one entry instead of duplicating.
+            cache_key = normalize_cache_key(url)
+
             # Check cache first
             if self.cache_enabled:
-                cached_response = self._get_cached_response(url)
+                cached_response = self._get_cached_response(cache_key)
                 if cached_response:
                     logger.debug(
                         "Cache hit",
@@ -230,7 +235,7 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             # otherwise be served stale for the whole TTL. Mirrors the Gemini
             # client, which excludes error/redirect/input/certificate results.
             if self.cache_enabled and getattr(response, "kind", None) != "error":
-                self._cache_response(url, response)
+                self._cache_response(cache_key, response)
 
             # Full URL/selector/search are request metadata; keep them at DEBUG
             # so default INFO logs don't record every browsed resource/query.

--- a/src/gopher_mcp/ssrf.py
+++ b/src/gopher_mcp/ssrf.py
@@ -207,6 +207,16 @@ async def validate_target(
         for addr in addresses:
             reason = classify_blocked_ip(addr)
             if reason is not None:
-                raise SSRFError(f"Blocked {reason} address for {host}: {addr}")
+                # Keep the resolved IP out of the caller-facing error: returning
+                # it would let a caller map internal topology by probing which
+                # hostnames land in private/reserved space. Log it server-side
+                # for operators, surface only the host and category.
+                logger.warning(
+                    "Blocked target resolving to internal address",
+                    host=host,
+                    reason=reason,
+                    resolved_ip=addr,
+                )
+                raise SSRFError(f"Blocked {reason} address for {host}")
 
     return addresses

--- a/src/gopher_mcp/utils.py
+++ b/src/gopher_mcp/utils.py
@@ -241,8 +241,14 @@ def parse_menu_line(line: str) -> GopherMenuItem | None:
         host = parts[2]
         # ``str.isdigit()`` accepts unicode digits (e.g. "²") that ``int()``
         # rejects; require ASCII so a bad port degrades to the default rather
-        # than dropping the whole menu item.
-        port = int(parts[3]) if parts[3].isascii() and parts[3].isdigit() else 70
+        # than dropping the whole menu item. Also bound the value: a numeric
+        # but out-of-range port (>65535) would otherwise fail model validation
+        # and drop the item -- degrade it to 70 instead.
+        port = 70
+        if parts[3].isascii() and parts[3].isdigit():
+            candidate = int(parts[3])
+            if 0 <= candidate <= 65535:
+                port = candidate
 
         # Construct the next URL. Percent-encode the selector (keeping '/')
         # so a selector containing spaces, '?', '#' or '%' round-trips back
@@ -286,7 +292,9 @@ def parse_gopher_menu(content: str) -> list[GopherMenuItem]:
     for line in normalized.split("\n"):
         # RFC 1436: a lone '.' terminates the menu. Stop here so data a server
         # places AFTER the terminator is never parsed into navigable items.
-        if line == ".":
+        # Strip trailing whitespace first so a non-conformant `. ` line still
+        # reads as the terminator instead of leaking later items to the model.
+        if line.strip() == ".":
             break
         item = parse_menu_line(line)
         if item:

--- a/src/gopher_mcp/utils.py
+++ b/src/gopher_mcp/utils.py
@@ -100,6 +100,19 @@ def atomic_write_json(file_path: str, data: Any) -> None:
         raise
 
 
+def bracket_host(host: str) -> str:
+    """Wrap an IPv6 literal host in brackets for use in a URL authority.
+
+    RFC 3986 requires an IPv6 address in a URL to be enclosed in ``[...]`` so
+    its colons are not confused with the host:port separator. A bare IPv4
+    address or registered name (already bracketed or containing no colon) is
+    returned unchanged.
+    """
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 def get_home_directory() -> Path | None:
     """Get the user's home directory with fallback handling.
 
@@ -234,7 +247,12 @@ def parse_menu_line(line: str) -> GopherMenuItem | None:
         # Construct the next URL. Percent-encode the selector (keeping '/')
         # so a selector containing spaces, '?', '#' or '%' round-trips back
         # through parse_gopher_url instead of mis-splitting into a bogus query.
-        next_url = f"gopher://{host}:{port}/{item_type}{quote(selector, safe='/')}"
+        # Bracket an IPv6 literal host so its colons don't collide with the
+        # port separator and break the re-parse.
+        next_url = (
+            f"gopher://{bracket_host(host)}:{port}/"
+            f"{item_type}{quote(selector, safe='/')}"
+        )
 
         return GopherMenuItem(
             type=item_type,
@@ -327,8 +345,8 @@ def format_gopher_url(
     # Sanitize inputs
     selector = sanitize_selector(selector)
 
-    # Build the URL
-    url = f"gopher://{host}"
+    # Build the URL (bracket an IPv6 literal host per RFC 3986)
+    url = f"gopher://{bracket_host(host)}"
 
     if port != 70:
         url += f":{port}"
@@ -536,8 +554,8 @@ def format_gemini_url(
         Formatted Gemini URL
 
     """
-    # Build the URL
-    url = f"gemini://{host}"
+    # Build the URL (bracket an IPv6 literal host per RFC 3986)
+    url = f"gemini://{bracket_host(host)}"
 
     # Only include port if it's not the default
     if port != 1965:

--- a/src/gopher_mcp/utils.py
+++ b/src/gopher_mcp/utils.py
@@ -7,7 +7,7 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any, Optional, Union
-from urllib.parse import quote, unquote, urljoin, urlparse
+from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit, urlunsplit
 
 from .models import (
     GeminiCertificateResult,
@@ -111,6 +111,21 @@ def bracket_host(host: str) -> str:
     if ":" in host and not host.startswith("["):
         return f"[{host}]"
     return host
+
+
+def normalize_cache_key(url: str) -> str:
+    """Canonicalize a URL for use as a cache key.
+
+    Hostnames are case-insensitive (RFC 3986), so requests differing only in
+    host case must map to the same entry instead of duplicating it. Lowercase
+    only the authority (host/port -- ports are digits, unaffected) and leave the
+    path/query byte-for-byte intact, since selectors and queries ARE
+    case-sensitive. An already-lowercase URL is returned unchanged.
+    """
+    parts = urlsplit(url)
+    return urlunsplit(
+        (parts.scheme, parts.netloc.lower(), parts.path, parts.query, parts.fragment)
+    )
 
 
 def get_home_directory() -> Path | None:

--- a/tests/test_client_certs.py
+++ b/tests/test_client_certs.py
@@ -391,6 +391,52 @@ class TestClientCertificateManager:
             result = manager.get_certificate_for_scope("example.com", 1965, "/")
             assert result is None
 
+    def test_get_certificate_for_scope_does_not_leak_across_sibling_paths(self):
+        """A cert scoped to /api must not be sent to a sibling like /api_admin.
+
+        Naive ``path.startswith(scope)`` matching would send the /api identity
+        to /api_admin, /api-private, etc., leaking client identity outside its
+        declared scope. Only the exact path or a true child (scope + '/') may
+        match.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manager = ClientCertificateManager(temp_dir)
+
+            manager.generate_certificate("example.com", 1965, "/api")
+
+            # Sibling paths sharing the textual prefix must NOT match.
+            assert (
+                manager.get_certificate_for_scope("example.com", 1965, "/api_admin")
+                is None
+            )
+            assert (
+                manager.get_certificate_for_scope("example.com", 1965, "/apixyz")
+                is None
+            )
+
+            # The exact path and genuine children still match.
+            assert (
+                manager.get_certificate_for_scope("example.com", 1965, "/api")
+                is not None
+            )
+            assert (
+                manager.get_certificate_for_scope("example.com", 1965, "/api/v1")
+                is not None
+            )
+
+    def test_extract_common_name_with_escaped_comma(self):
+        """RFC 4514 escapes commas inside a CN value as ``\\,``.
+
+        Splitting the subject on raw commas truncates such a CN; the registry
+        filename derived from it would then not match the file on disk, making
+        the certificate unusable. The parser must unescape correctly.
+        """
+        with patch.object(ClientCertificateManager, "_load_registry"):
+            manager = ClientCertificateManager("/tmp/test")
+
+            subject = "CN=test\\, name,O=Gemini Client"
+            assert manager._extract_common_name(subject) == "test, name"
+
     def test_remove_certificate_success(self):
         """Test successful certificate removal."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from gopher_mcp.gemini_client import GeminiClient
+from gopher_mcp.gemini_client import GeminiClient, _safe_display_url
 from gopher_mcp.gemini_tls import TLSConfig, TLSConnectionError
 from gopher_mcp.models import (
     GeminiErrorResult,
@@ -510,6 +510,53 @@ class TestGeminiClientFetchContent:
             sent_data = mock_send.call_args[0][1]
             expected_request = b"gemini://example.com/test?search\r\n"
             assert sent_data == expected_request
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_brackets_ipv6_host_on_the_wire(self):
+        """An IPv6 literal host must be bracketed in the request line sent.
+
+        Per RFC 3986 the address must be ``[..]`` so a server (and any URL
+        re-parse) can tell the address colons from a port separator.
+        """
+        client = GeminiClient()
+
+        mock_parsed_url = Mock()
+        mock_parsed_url.host = "2606:4700:4700::1111"  # globally routable IPv6
+        mock_parsed_url.port = 1966
+        mock_parsed_url.path = "/p"
+        mock_parsed_url.query = ""
+
+        mock_connection_info = {"cert_fingerprint": "abc123"}
+        mock_result = GeminiSuccessResult(
+            content="ok",
+            mimeType=GeminiMimeType(type="text", subtype="plain"),
+            size=2,
+            requestInfo={},
+        )
+        with (
+            patch.object(client.tls_client, "connect") as mock_connect,
+            patch.object(client.tls_client, "send_data") as mock_send,
+            patch.object(client.tls_client, "receive_data") as mock_receive,
+            patch.object(client.tls_client, "close"),
+            patch("gopher_mcp.gemini_client.parse_gemini_response"),
+            patch("gopher_mcp.gemini_client.process_gemini_response") as mock_process,
+        ):
+            mock_connect.return_value = (Mock(), mock_connection_info)
+            mock_receive.return_value = b"20 text/plain\r\nok"
+            mock_process.return_value = mock_result
+
+            await client._fetch_content(mock_parsed_url)
+
+            sent_data = mock_send.call_args[0][1]
+            assert sent_data == b"gemini://[2606:4700:4700::1111]:1966/p\r\n"
+
+    def test_safe_display_url_brackets_ipv6_host(self):
+        """The display/log helper must also bracket IPv6 hosts."""
+        parsed = Mock()
+        parsed.host = "2001:db8::1"
+        parsed.port = 1965
+        parsed.path = "/x"
+        assert _safe_display_url(parsed) == "gemini://[2001:db8::1]/x"
 
     @pytest.mark.asyncio
     async def test_fetch_content_tls_error(self):

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -1,5 +1,6 @@
 """Tests for Gemini client implementation."""
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -557,6 +558,36 @@ class TestGeminiClientFetchContent:
         parsed.port = 1965
         parsed.path = "/x"
         assert _safe_display_url(parsed) == "gemini://[2001:db8::1]/x"
+
+    @pytest.mark.asyncio
+    async def test_send_is_bounded_by_request_deadline(self):
+        """A peer that completes the handshake then stops reading must not pin
+        the request forever: the send must run under the request deadline, the
+        same as the receive does (and as the Gopher transport already does)."""
+        client = GeminiClient()
+        client.timeout_seconds = 0.05
+        client.tofu_manager = None  # isolate from the on-disk trust store
+
+        parsed = Mock()
+        parsed.host = "example.com"
+        parsed.port = 1965
+        parsed.path = "/"
+        parsed.query = ""
+
+        async def hanging_send(*args, **kwargs):
+            await asyncio.sleep(0.5)  # far longer than the 0.05s deadline
+
+        with (
+            patch.object(client.tls_client, "connect") as mock_connect,
+            patch.object(client.tls_client, "send_data", side_effect=hanging_send),
+            patch.object(client.tls_client, "receive_data"),
+            patch.object(client.tls_client, "close"),
+            patch("gopher_mcp.gemini_client.parse_gemini_response"),
+            patch("gopher_mcp.gemini_client.process_gemini_response"),
+        ):
+            mock_connect.return_value = (Mock(), {"cert_fingerprint": "abc"})
+            with pytest.raises(TimeoutError):
+                await client._fetch_content(parsed)
 
     @pytest.mark.asyncio
     async def test_fetch_content_tls_error(self):

--- a/tests/test_gopher_client.py
+++ b/tests/test_gopher_client.py
@@ -433,6 +433,30 @@ class TestFetchMethod:
             cached_entry = client._cache[url]
             assert cached_entry.value == expected_result
 
+    @pytest.mark.asyncio
+    async def test_fetch_does_not_cache_error_result(self):
+        """An ErrorResult must not be cached: a transient failure would
+        otherwise be served stale for the whole TTL. Matches the Gemini client,
+        which already excludes error/redirect/input/certificate results."""
+        client = GopherClient()
+        url = "gopher://example.com/1/"
+
+        with (
+            patch("gopher_mcp.utils.parse_gopher_url") as mock_parse,
+            patch.object(client, "_fetch_content") as mock_fetch,
+        ):
+            mock_parse.return_value = GopherURL(
+                host="example.com", port=70, gopherType="1", selector="/", search=None
+            )
+            mock_fetch.return_value = ErrorResult(
+                error={"code": "UNSUPPORTED_TYPE", "message": "nope"},
+                requestInfo={},
+            )
+
+            result = await client.fetch(url)
+            assert isinstance(result, ErrorResult)
+            assert url not in client._cache
+
 
 class TestResponseProcessing:
     """Test response processing methods against real raw bytes."""

--- a/tests/test_gopher_client.py
+++ b/tests/test_gopher_client.py
@@ -434,6 +434,25 @@ class TestFetchMethod:
             assert cached_entry.value == expected_result
 
     @pytest.mark.asyncio
+    async def test_cache_is_case_insensitive_for_hostname(self):
+        """Hostnames are case-insensitive (RFC 3986), so a request that differs
+        only in host case must hit the same cache entry rather than creating a
+        duplicate and re-fetching."""
+        client = GopherClient()
+        expected_result = MenuResult(items=[])
+
+        with patch.object(client, "_fetch_content") as mock_fetch:
+            mock_fetch.return_value = expected_result
+
+            first = await client.fetch("gopher://Example.COM/1/")
+            second = await client.fetch("gopher://example.com/1/")
+
+            assert first == expected_result
+            assert second == expected_result
+            # The second request is served from cache -- no second fetch.
+            assert mock_fetch.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_fetch_does_not_cache_error_result(self):
         """An ErrorResult must not be cached: a transient failure would
         otherwise be served stale for the whole TTL. Matches the Gemini client,

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -84,6 +84,18 @@ class TestValidateTarget:
         with pytest.raises(SSRFError, match="Blocked"):
             await validate_target(host, 1965)
 
+    async def test_resolved_internal_ip_not_leaked_in_error(self):
+        """The error returned to the caller must name the host and category but
+        NOT the resolved internal IP -- otherwise a caller can map internal
+        network topology by probing which hostnames resolve to private space.
+        The stub resolves ``*.internal`` to 10.0.0.5."""
+        with pytest.raises(SSRFError) as exc_info:
+            await validate_target("db.internal", 1965)
+        message = str(exc_info.value)
+        assert "10.0.0.5" not in message
+        assert "db.internal" in message
+        assert "private" in message
+
     async def test_allow_local_bypasses_check(self):
         # No exception even though localhost resolves to loopback.
         await validate_target("localhost", 70, allow_local=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -275,6 +275,20 @@ invalid line
         assert len(result) == 1
         assert result[0].title == "Before"
 
+    def test_stops_at_terminator_with_trailing_whitespace(self):
+        """A terminator line carrying trailing whitespace (`. `) must still
+        terminate the menu, so a non-conformant server cannot slip navigable
+        items past what reads as the end of the listing."""
+        content = (
+            "1Before\t/before\texample.com\t70\r\n"
+            ". \r\n"
+            "1AfterTerminator\t/evil\tattacker.example\t70\r\n"
+        )
+        result = parse_gopher_menu(content)
+
+        assert len(result) == 1
+        assert result[0].title == "Before"
+
 
 class TestSanitizeSelector:
     """Test sanitize_selector function."""
@@ -464,6 +478,13 @@ class TestGopherUrlPortAndSelectorHandling:
     def test_menu_line_non_ascii_digit_port_defaults_to_70(self):
         """A non-ASCII 'digit' port must default to 70, not drop the item."""
         item = parse_menu_line("0Title\t/sel\texample.com\t²")
+        assert item is not None
+        assert item.port == 70
+
+    def test_menu_line_out_of_range_port_defaults_to_70(self):
+        """A numeric but out-of-range port (>65535) must degrade to 70 rather
+        than failing model validation and dropping the whole menu item."""
+        item = parse_menu_line("0Title\t/sel\texample.com\t99999")
         assert item is not None
         assert item.port == 70
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 
 from gopher_mcp.utils import (
     atomic_write_json,
+    format_gemini_url,
     format_gopher_url,
     guess_mime_type,
     parse_gopher_menu,
@@ -343,6 +344,50 @@ class TestFormatGopherUrl:
         """Test that search is ignored for non-search types."""
         result = format_gopher_url("example.com", gopher_type="1", search="test")
         assert result == "gopher://example.com/1"
+
+    def test_ipv6_host_is_bracketed(self):
+        """An IPv6 literal host must be wrapped in brackets per RFC 3986.
+
+        Without brackets the colons in the address collide with the port
+        separator, producing a URL that re-parses incorrectly.
+        """
+        result = format_gopher_url("::1", port=70)
+        assert result == "gopher://[::1]/1"
+
+    def test_ipv6_host_with_port_is_bracketed(self):
+        """Brackets must separate an IPv6 host from an explicit port."""
+        result = format_gopher_url("2001:db8::1", port=7070)
+        assert result == "gopher://[2001:db8::1]:7070/1"
+
+
+class TestFormatGeminiUrl:
+    """IPv6 bracketing for Gemini URL construction."""
+
+    def test_ipv6_host_is_bracketed(self):
+        assert format_gemini_url("::1") == "gemini://[::1]/"
+
+    def test_ipv6_host_with_port_is_bracketed(self):
+        assert (
+            format_gemini_url("2001:db8::1", port=1966)
+            == "gemini://[2001:db8::1]:1966/"
+        )
+
+    def test_regular_host_unchanged(self):
+        assert format_gemini_url("example.com", path="/x") == "gemini://example.com/x"
+
+
+class TestParseMenuLineIPv6:
+    """A menu item whose host is an IPv6 literal must yield a re-parseable URL."""
+
+    def test_ipv6_host_next_url_round_trips(self):
+        line = "0Title\t/sel\t::1\t70"
+        item = parse_menu_line(line)
+        assert item is not None
+        assert item.next_url == "gopher://[::1]:70/0/sel"
+        # The constructed nextUrl must parse back without a port-split error.
+        parsed = parse_gopher_url(item.next_url)
+        assert parsed.host == "::1"
+        assert parsed.port == 70
 
 
 class TestGuessMimeType:


### PR DESCRIPTION
## Summary

Correctness and hardening fixes surfaced by an end-to-end review of the codebase. Each is small and localized, ships with a regression test (written test-first), and every claim was adversarially re-checked against the source. The automated gates were already green; these address logic/edge-case gaps the gates can't see.

### Security
- **Client-cert path scope** — matching used a raw `startswith`, so an `/api`-scoped certificate was sent to siblings like `/api_admin`, leaking the client identity outside its declared scope. Now matched on path-segment boundaries.
- **SSRF error redaction** — a blocked target that resolved to an internal address echoed the resolved IP back to the caller, usable to map internal topology. The IP is now logged server-side only; the caller sees host + category.
- **Gemini send deadline** — only the receive was bounded by the request deadline; a peer that finished the handshake then stopped reading could block the send. Now wrapped like the receive (and the Gopher transport).
- **Padded menu terminator** — the RFC 1436 `.` terminator check now tolerates trailing whitespace, so a non-conformant `". "` line can't slip later items past the end of a listing.

### Fixed
- **Client-cert CN parsing** — a CN with an escaped comma was truncated (it's used to derive the on-disk filename), silently disabling the cert. Parsed via the cryptography library now.
- **IPv6 host bracketing** — IPv6 literal hosts were interpolated bare, producing `gopher://::1:70/...` that won't re-parse and an unbracketed Gemini authority on the wire. A shared `bracket_host` helper is applied at every URL-construction site.
- **Out-of-range menu port** — a numeric port > 65535 dropped the whole menu item; it now degrades to the default 70.
- **Gopher error caching** — the Gopher client cached error responses (the Gemini client already filtered them), serving a transient failure stale for the TTL. Now skipped.
- **Cache key case** — response cache keys are now case-insensitive in the hostname, so host-case variants share one entry.

### Docs
- Corrected the API reference (fresh connection per request — no pooling), removed the non-existent `GOPHER_HTTP_HOST`/`GOPHER_HTTP_PORT` env vars (host/port are `--host`/`--port` CLI flags), and documented that the HTTP transports are unauthenticated and the Docker image binds `0.0.0.0:8000` by default.

## Test Plan
- [x] `ruff check .` — clean
- [x] `mypy src/ --strict` — no issues (15 files)
- [x] `pytest` — 680 passed (16 new regression tests), coverage 93.55% (gate ≥85%)
- [x] `bandit -r src/` — clean
- [x] `pip-audit` — no known vulnerabilities
- [x] `mkdocs build --strict` — clean