### PR TITLE
test: isolate the suite from the real home directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,31 @@
 """Pytest configuration and shared fixtures for gopher-mcp tests."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect the home directory to a per-test tmp dir.
+
+    A default ``GeminiClient()`` builds a ``TOFUManager`` and a
+    ``ClientCertificateManager`` whose storage defaults to ``~/.gemini`` (via
+    ``get_home_directory()`` -> ``Path.home()``). Without this, every test that
+    constructs a default client would *read and write the developer's real home
+    directory* -- creating ``~/.gemini/certs`` and ``~/.gemini/tofu.json``.
+
+    ``Path.home()`` honours ``$HOME`` on POSIX and ``$USERPROFILE`` on Windows,
+    so monkeypatching both is the cleanest mechanism the code already supports;
+    it needs no knowledge of every ``get_home_directory`` import site. Returned
+    so tests that assert on the isolated location can request it by name.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_home_isolation.py
+++ b/tests/test_home_isolation.py
@@ -1,0 +1,69 @@
+"""Regression tests: the suite must never read or write the real home directory.
+
+A default ``GeminiClient()`` builds a ``TOFUManager`` and a
+``ClientCertificateManager`` whose storage defaults to ``~/.gemini/tofu.json``
+and ``~/.gemini/certs``. Without test isolation, running the suite would read
+and *write the real user home*. The autouse ``isolated_home`` fixture in
+``conftest.py`` redirects ``$HOME`` / ``$USERPROFILE`` to a per-test tmp dir;
+these tests fail if that isolation ever regresses.
+"""
+
+from pathlib import Path
+
+from gopher_mcp.gemini_client import GeminiClient
+from gopher_mcp.utils import get_home_directory
+
+# Captured at import time -- before any per-test HOME monkeypatch runs -- so it
+# is the developer's actual home directory regardless of the isolation fixture.
+_REAL_HOME = Path.home()
+_REAL_GEMINI_DIR = _REAL_HOME / ".gemini"
+
+
+def test_home_directory_is_isolated_from_real_home() -> None:
+    """``get_home_directory()`` must not resolve to the real home during tests.
+
+    Fails without the autouse isolation fixture: ``get_home_directory()`` would
+    return the developer's real home. This check performs no filesystem access,
+    so even the failing (pre-fixture) state leaves the real ``~/.gemini``
+    untouched.
+    """
+    home = get_home_directory()
+    assert home is not None
+    assert home != _REAL_HOME, (
+        "Tests resolved the REAL home directory -- the autouse home-isolation "
+        "fixture is not active, so the suite would read/write ~/.gemini."
+    )
+
+
+def test_default_gemini_client_stores_under_isolated_home(
+    isolated_home: Path,
+) -> None:
+    """Default manager storage must live under the isolated home, not the real one."""
+    client = GeminiClient()
+
+    assert client.tofu_manager is not None
+    assert client.client_cert_manager is not None
+
+    tofu_path = Path(client.tofu_manager.storage_path)
+    cert_path = Path(client.client_cert_manager.storage_path)
+
+    # Resolved under the per-test isolated home...
+    assert isolated_home in tofu_path.parents
+    assert isolated_home in cert_path.parents
+    # ...and never under the developer's real ~/.gemini.
+    assert _REAL_GEMINI_DIR not in tofu_path.parents
+    assert _REAL_GEMINI_DIR not in cert_path.parents
+
+
+def test_tofu_write_lands_in_isolated_home(isolated_home: Path) -> None:
+    """A real TOFU write must land in the isolated home, never the real one."""
+    client = GeminiClient()
+    assert client.tofu_manager is not None
+
+    # Exercises the actual on-disk write path (atomic_write_json).
+    client.update_tofu_certificate("example.org", 1965, "a" * 64)
+
+    written = Path(client.tofu_manager.storage_path)
+    assert written.exists()
+    assert isolated_home in written.parents
+    assert _REAL_GEMINI_DIR not in written.parents


### PR DESCRIPTION
## Summary

Running `uv run pytest` instantiated default `GeminiClient()`s whose `TOFUManager` and `ClientCertificateManager` default their storage to `~/.gemini/tofu.json` and `~/.gemini/certs`. The suite therefore **read and wrote the developer's real home directory** — creating `~/.gemini/certs/` and `~/.gemini/tofu.json`, and emitting a `TOFU entries loaded ... storage_path=/Users/<you>/.gemini/tofu.json` log line during the run.

This adds an autouse fixture that redirects `$HOME`/`$USERPROFILE` to a per-test tmp dir. That is the cleanest lever available: `get_home_directory()` is the **sole** home-resolving site in `src/` (called only by the two managers), and it goes through `Path.home()` with a `HOME`/`USERPROFILE` fallback — both of which honour those env vars. No production code changes; nothing else in `src/` touches the home, XDG, or any user config/cache dir.

### Changes
- `tests/conftest.py` — new autouse `isolated_home` fixture (monkeypatches `HOME`/`USERPROFILE` to `tmp_path/home`, returns the path so tests can assert on it).
- `tests/test_home_isolation.py` — regression tests that fail if the isolation regresses:
  - `get_home_directory()` no longer resolves to the real home (no filesystem access);
  - a default `GeminiClient()` stores TOFU + client-cert data under the isolated home and never under the real `~/.gemini`;
  - a real TOFU write lands in the isolated home.

## Test Plan
- Demonstrated the regression test fails **without** the fixture: `get_home_directory()` returned the real `/Users/<me>` and the assertion tripped (no FS touched in that path).
- With the fixture, all three regression tests pass and the TOFU log line now points at `/var/folders/.../tmp.../tofu.json`.
- Full gate green:
  - `uv run ruff check .` — passed
  - `uv run mypy src/ --ignore-missing-imports` — passed
  - `uv run pytest` — **683 passed**, coverage **93.62%** (≥85 gate)
  - `uv run bandit -r src/ -q` — clean
  - `uv run pip-audit` — no known vulnerabilities
- Confirmed no `cameron`/real-home path appears anywhere in suite output.