### PR TITLE
chore(release): 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-06-10
+
 ### Security
 
 - The Gopher menu parser now stops at the RFC 1436 `.` terminator, so data a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gopher-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "A cross-platform Model Context Protocol (MCP) server for browsing Gopher and Gemini resources"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.cameronrye/gopher-mcp",
   "description": "MCP server for browsing Gopher and Gemini protocol resources safely, with SSRF protection, TLS/TOFU, and structured JSON output.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "repository": {
     "url": "https://github.com/cameronrye/gopher-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registry_type": "pypi",
       "registry_base_url": "https://pypi.org",
       "identifier": "gopher-mcp",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ wheels = [
 
 [[package]]
 name = "gopher-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Release 0.4.3

Promotes the unreleased protocol/security correctness fixes (from #55/#56) to a tagged release, alongside the recently merged test-hardening and refactor work (#57, #58, #60 — internal, no user-facing changes).

### Version bumps
- `pyproject.toml`, `server.json` (both the top-level and `packages[0]` fields), and the `uv.lock` workspace pin → **0.4.3**
- `CHANGELOG.md`: `[Unreleased]` promoted to `[0.4.3] - 2026-06-10`
- `src/gopher_mcp/__init__.py` intentionally untouched (derives `__version__` from `importlib.metadata`)

### Released changes (user-facing, from the Unreleased section)
- **Security:** RFC 1436 `.` terminator stops menu parsing (incl. trailing-whitespace tolerance); client certs scoped on path-segment boundaries; blocked SSRF target no longer echoes the resolved internal IP; Gemini request send bounded by the deadline.
- **Fixed:** status-20 bad-MIME defaults to `text/gemini`; client-cert host normalization; robust CN parsing; IPv6 hosts bracketed in all constructed URLs; out-of-range menu port degrades to 70; gopher errors no longer cached; case-insensitive cache-key host; `GopherURL` rejects empty host.
- **Changed:** doc corrections; supply-chain hygiene (`.dockerignore`, SHA-pinned actions, `cryptography>=43`).

On merge, I'll tag `v0.4.3` on `main`, which triggers the release workflow (validate → build → attest → PyPI trusted publishing → GitHub release).