### PR TITLE
fix: end-to-end review follow-ups (SLOW_DOWN DoS, protocol errors, release tooling)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,24 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+
+  # Docker base image (Dockerfile uses python:3.x-slim in both stages). Without
+  # this the runtime image's base never gets automated CVE-bump PRs, unlike
+  # every other dependency in the repo.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "cameronrye"
+    assignees:
+      - "cameronrye"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Run tests
         run: uv run pytest
@@ -70,7 +70,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Run Gemini-specific tests
         # --no-cov: this runs only the Gemini subset, so it cannot meet the
@@ -130,7 +130,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Run ruff linting
         run: uv run ruff check .
@@ -160,7 +160,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Run bandit security linting
         run: uv run bandit -r src/ -f json -o bandit-report.json
@@ -196,7 +196,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --extra docs
+        run: uv sync --locked --extra docs
 
       - name: Build documentation
         run: uv run mkdocs build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,11 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
+      # The API reference renders docstrings/models from source via
+      # mkdocstrings, so a source change must redeploy the site too -- otherwise
+      # the published reference silently drifts from the code.
+      - 'src/**'
+      - 'uv.lock'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -43,7 +48,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --extra docs
+        run: uv sync --locked --extra docs
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,19 @@
-name: Publish to PyPI
+name: Publish to TestPyPI
 
+# Manual TestPyPI publishing only. Real PyPI releases are driven by release.yml
+# on a pushed v* tag (with PyPI environment protection + trusted publishing) --
+# this workflow deliberately does NOT publish to PyPI, so it offers no 'pypi'
+# target (a 'pypi' choice here would build, report success, and publish nothing).
 on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Target repository'
+        description: 'Target repository (TestPyPI only)'
         required: true
         default: 'testpypi'
         type: choice
         options:
           - testpypi
-          - pypi
 
 # Least-privilege default; the publish jobs opt into id-token: write.
 permissions:
@@ -42,7 +45,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Run tests
         run: uv run pytest --cov-report=xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Run full test suite
         run: uv run pytest --cov-report=xml --cov-report=term
@@ -215,8 +215,12 @@ jobs:
 
           # Extract changelog section for this version
           if grep -q "## \[${VERSION}\]" CHANGELOG.md; then
-            # Extract content between this version and the next version header
-            NOTES=$(awk "/## \[${VERSION}\]/{flag=1; next} /## \[/{flag=0} flag" CHANGELOG.md | sed '/^$/d' | head -n -1)
+            # Extract content between this version and the next version header.
+            # awk already stops before the next "## [" header, and sed strips
+            # blank lines -- do NOT pipe through `head -n -1`: the trailing blank
+            # it was meant to trim is already gone, so it would drop the last
+            # real line of the section (truncating every release's notes).
+            NOTES=$(awk "/## \[${VERSION}\]/{flag=1; next} /## \[/{flag=0} flag" CHANGELOG.md | sed '/^$/d')
 
             if [[ -z "$NOTES" ]]; then
               NOTES="Release version ${VERSION}"

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -40,7 +40,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --locked --all-extras
 
       - name: Check code formatting
         run: uv run ruff format --check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- A malicious Gemini server can no longer hang the client with an unbounded
+  status-44 (SLOW_DOWN) backoff. The server-supplied wait is now sanitized and
+  clamped (a non-finite value such as `inf` is rejected/capped), so a single
+  `44 inf` response can no longer make every later fetch to that host sleep
+  forever while holding a concurrency-semaphore slot.
+- The Gemini TLS close handshake is now time-bounded, so a peer that withholds
+  `close_notify` can no longer tack the OS TCP timeout onto each request after
+  the read deadline has already been met.
+
+### Fixed
+
+- A server-side Gemini protocol fault (missing CRLF, over-long meta, bad status
+  line, empty response) now returns a distinct `PROTOCOL_ERROR` instead of
+  `INVALID_REQUEST`, so the model is told the server misbehaved rather than that
+  its own URL was malformed.
+- A spec-valid comma-separated `lang` parameter (e.g. `lang=en,fr`) is no longer
+  rejected; rejecting it previously discarded the whole MIME type, including the
+  declared charset, producing mojibake or gemtext misclassification.
+- A stray unprefixed `GOPHER` / `GEMINI` / `SERVER` environment variable set by
+  unrelated tooling no longer crashes startup (it was misread as the nested
+  config object).
+
+### Changed
+
+- Release/CI hygiene: `prepare-release.py` now bumps the version with an anchored
+  match (no longer corrupting `target-version` / `python_version` / `minversion`
+  in `pyproject.toml`) and also updates `server.json`; GitHub release notes no
+  longer drop the last line of each changelog section; all CI/release/publish
+  jobs run `uv sync --locked` so a stale lockfile fails loudly; the
+  manual-publish workflow no longer offers a no-op `pypi` target; Dependabot now
+  covers the Docker base image; and the docs site redeploys on `src/**` changes
+  so the mkdocstrings API reference can't drift.
+
 ## [0.4.3] - 2026-06-10
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,11 @@ install-hooks = "pre-commit install"
 # hides violations in task.py/scripts/ that CI would still fail on)
 lint = "ruff check ."
 format = "ruff format ."
-typecheck = "mypy src/ --ignore-missing-imports"
+# Match CI's `mypy src` exactly: --ignore-missing-imports globally suppresses
+# missing-stub errors, so a new untyped import passes locally but fails CI.
+# The scoped [[tool.mypy.overrides]] for genuinely stub-less packages covers
+# the legitimate case.
+typecheck = "mypy src"
 quality = "uv run task lint && uv run task typecheck && uv run task test"
 
 # Testing

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -34,7 +34,9 @@ class ReleasePreparation:
             raise FileNotFoundError("pyproject.toml not found!")
 
         content = pyproject_path.read_text()
-        match = re.search(r'version = "([^"]+)"', content)
+        # Anchor to the start of a line so we read [project].version and not a
+        # substring of target-version / python_version / minversion.
+        match = re.search(r'^version = "([^"]+)"', content, flags=re.MULTILINE)
         if not match:
             raise ValueError("Version not found in pyproject.toml!")
 
@@ -46,15 +48,44 @@ class ReleasePreparation:
         return bool(re.match(pattern, version))
 
     def _update_version(self, new_version: str) -> None:
-        """Update version in pyproject.toml."""
+        """Update the version in pyproject.toml and server.json.
+
+        The release workflow validates that pyproject.toml AND server.json (its
+        two version fields) all match the tag, so both must be bumped here -- a
+        pyproject-only bump produces a tag push that fails at validate-release.
+        """
+        # pyproject.toml: anchor to the start of a line and replace only the
+        # first match, so we don't rewrite target-version / python_version /
+        # minversion (which an unanchored substring match would clobber, breaking
+        # ruff/mypy/pytest config).
         pyproject_path = self.project_root / "pyproject.toml"
         content = pyproject_path.read_text()
-
-        # Update version
-        content = re.sub(r'version = "[^"]+"', f'version = "{new_version}"', content)
-
+        content, n = re.subn(
+            r'^version = "[^"]+"',
+            f'version = "{new_version}"',
+            content,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        if n != 1:
+            raise ValueError("Could not locate [project].version in pyproject.toml")
         pyproject_path.write_text(content)
         print(f"✅ Updated version to {new_version} in pyproject.toml")
+
+        # server.json: the MCP registry manifest carries the version twice (the
+        # top-level field and each package entry). Use json load/dump so we touch
+        # only the version fields and preserve formatting elsewhere.
+        server_json_path = self.project_root / "server.json"
+        if server_json_path.exists():
+            import json
+
+            data = json.loads(server_json_path.read_text())
+            data["version"] = new_version
+            for package in data.get("packages", []):
+                if "version" in package:
+                    package["version"] = new_version
+            server_json_path.write_text(json.dumps(data, indent=2) + "\n")
+            print(f"✅ Updated version to {new_version} in server.json")
 
     def _update_changelog(self, version: str) -> None:
         """Update CHANGELOG.md with new version."""

--- a/src/gopher_mcp/config.py
+++ b/src/gopher_mcp/config.py
@@ -312,6 +312,14 @@ class AppConfig(BaseSettings):
     server: ServerConfig = Field(default_factory=ServerConfig)
 
     model_config = SettingsConfigDict(
+        # Namespace the (complex) nested fields so a bare ``GOPHER``/``GEMINI``/
+        # ``SERVER`` env var set by unrelated tooling is NOT mistaken for the
+        # whole sub-config object -- without this, pydantic-settings tries to
+        # JSON-parse that value and crashes startup with a SettingsError. The
+        # sub-configs are populated by their default_factory (each reading its
+        # own ``GOPHER_``/``GEMINI_``/``GOPHER_MCP_`` prefix), so this prefix only
+        # closes the bare-name collision; it is not expected to match anything.
+        env_prefix="GOPHER_MCP_APP_",
         env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",

--- a/src/gopher_mcp/gemini_client.py
+++ b/src/gopher_mcp/gemini_client.py
@@ -8,6 +8,7 @@ import structlog
 
 from .cache import TTLCacheMixin
 from .client_certs import ClientCertificateManager
+from .gemini_parse import GeminiProtocolError
 from .gemini_tls import GeminiTLSClient, TLSConfig, TLSConnectionError
 from .models import (
     GeminiCacheEntry,
@@ -297,6 +298,18 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         except TimeoutError as e:
             # DNS resolution, connect, or read exceeded the request deadline.
             return self._error_result(url, "FETCH_ERROR", "The request timed out", e)
+        except GeminiProtocolError as e:
+            # The SERVER sent a malformed response (missing CRLF, bad status,
+            # over-long meta, ...). Report it as a server-side fault rather than
+            # INVALID_REQUEST, which would wrongly tell the model to fix its URL.
+            # Must precede the ValueError handler (it is a subclass). The message
+            # describes the response shape only -- no body bytes or secrets.
+            return self._error_result(
+                url,
+                "PROTOCOL_ERROR",
+                f"The server sent a malformed Gemini response: {e}",
+                e,
+            )
         except ValueError as e:
             # URL/host validation errors are safe to surface verbatim.
             return self._error_result(url, "INVALID_REQUEST", str(e), e)

--- a/src/gopher_mcp/gemini_parse.py
+++ b/src/gopher_mcp/gemini_parse.py
@@ -33,6 +33,17 @@ from .models import (
 )
 
 
+class GeminiProtocolError(ValueError):
+    """A server sent a malformed Gemini response (a server-side fault).
+
+    Distinct from a client-side URL/host validation error: the client mapped
+    those to ``INVALID_REQUEST`` and these to ``PROTOCOL_ERROR`` so the model is
+    told the server misbehaved rather than that its own request was wrong.
+    Subclasses :class:`ValueError` so existing ``except ValueError`` handlers and
+    ``pytest.raises(ValueError)`` callers keep working.
+    """
+
+
 def parse_gemini_url(url: str) -> GeminiURL:
     """Parse a Gemini URL into its components.
 
@@ -192,13 +203,13 @@ def parse_gemini_response(raw_response: bytes) -> "GeminiResponse":
         ValueError: If response format is invalid
     """
     if not raw_response:
-        raise ValueError("Empty response")
+        raise GeminiProtocolError("Empty response")
 
     try:
         # Find the end of the status line (CRLF)
         crlf_pos = raw_response.find(b"\r\n")
         if crlf_pos == -1:
-            raise ValueError("Invalid response format: missing CRLF")
+            raise GeminiProtocolError("Invalid response format: missing CRLF")
 
         # Extract status line and body
         status_line = raw_response[:crlf_pos].decode("utf-8")
@@ -206,10 +217,12 @@ def parse_gemini_response(raw_response: bytes) -> "GeminiResponse":
 
         # Parse status line: "<STATUS><SPACE><META>"
         if len(status_line) < 3:  # Minimum: "XX "
-            raise ValueError("Status line too short")
+            raise GeminiProtocolError("Status line too short")
 
         if status_line[2] != " ":
-            raise ValueError("Invalid status line format: missing space after status")
+            raise GeminiProtocolError(
+                "Invalid status line format: missing space after status"
+            )
 
         # Extract status code and meta
         status_str = status_line[:2]
@@ -220,17 +233,17 @@ def parse_gemini_response(raw_response: bytes) -> "GeminiResponse":
         # target URL, so truncation would hand back a corrupted URL pointing
         # somewhere other than intended instead of a clear protocol error.
         if len(meta.encode("utf-8")) > 1024:
-            raise ValueError("Meta field exceeds 1024 bytes")
+            raise GeminiProtocolError("Meta field exceeds 1024 bytes")
 
         # Validate status code
         if not status_str.isdigit():
-            raise ValueError(f"Invalid status code: {status_str}")
+            raise GeminiProtocolError(f"Invalid status code: {status_str}")
 
         status_code = int(status_str)
 
         # Validate status code range
         if not (10 <= status_code <= 69):
-            raise ValueError(f"Status code out of range: {status_code}")
+            raise GeminiProtocolError(f"Status code out of range: {status_code}")
 
         # Convert to enum
         try:
@@ -242,12 +255,13 @@ def parse_gemini_response(raw_response: bytes) -> "GeminiResponse":
         return GeminiResponse(status=status_enum, meta=meta, body=body)
 
     except UnicodeDecodeError as e:
-        raise ValueError(f"Invalid UTF-8 in status line: {e}") from e
+        raise GeminiProtocolError(f"Invalid UTF-8 in status line: {e}") from e
     except ValueError:
-        # Re-raise our own validation errors unchanged (don't double-wrap).
+        # Re-raise our own protocol/validation errors unchanged (GeminiProtocolError
+        # is a ValueError subclass; don't double-wrap).
         raise
     except Exception as e:
-        raise ValueError(f"Failed to parse response: {e}") from e
+        raise GeminiProtocolError(f"Failed to parse response: {e}") from e
 
 
 def process_gemini_response(

--- a/src/gopher_mcp/gemini_tls.py
+++ b/src/gopher_mcp/gemini_tls.py
@@ -22,6 +22,11 @@ import structlog
 logger = structlog.get_logger(__name__)
 
 READ_CHUNK = 65536
+# Grace period for a TLS close handshake. ``wait_closed`` waits for the peer's
+# close_notify; a peer that withholds it would otherwise block until the OS TCP
+# timeout (~30s+), adding that to every request *beyond* the configured deadline
+# (close runs in a finally, after the read deadline has already been met).
+CLOSE_TIMEOUT_SECONDS = 5.0
 # Short probe deadline used once the size cap is reached: a server that sent
 # exactly ``max_size`` bytes and then holds the connection open (delayed/absent
 # close_notify) would otherwise block until the request deadline. A probe
@@ -300,10 +305,14 @@ class GeminiTLSClient:
             conn: The connection to close
         """
         conn.writer.close()
-        # Best-effort: ignore errors (incl. SSL close_notify hiccups) so they
-        # don't mask the result the caller already obtained.
+        # Best-effort, and time-bounded: ignore errors (incl. SSL close_notify
+        # hiccups) so they don't mask the result the caller already obtained, and
+        # cap the wait so a peer withholding close_notify can't tack the OS TCP
+        # timeout onto every request past the deadline.
         with contextlib.suppress(Exception):
-            await conn.writer.wait_closed()
+            await asyncio.wait_for(
+                conn.writer.wait_closed(), timeout=CLOSE_TIMEOUT_SECONDS
+            )
 
     async def send_data(self, conn: TLSConnection, data: bytes) -> None:
         """Send data over the TLS connection.

--- a/src/gopher_mcp/mime.py
+++ b/src/gopher_mcp/mime.py
@@ -211,12 +211,16 @@ def validate_gemini_mime_type(mime_type: "GeminiMimeType") -> bool:
     if mime_type.is_text and not mime_type.charset:
         return False
 
-    # Validate language tag format (basic check)
+    # Validate language tag format (basic check). The Gemini spec permits a
+    # comma-separated LIST of BCP47 tags (e.g. "en,fr"), so validate each tag
+    # rather than the whole string -- a bare letters/numbers/hyphens regex would
+    # reject a spec-valid list, and the caller then discards the entire MIME type
+    # (charset included) on that failure.
     if mime_type.lang:
-        # Basic BCP47 validation - should contain only letters, numbers, and hyphens
         import re
 
-        if not re.match(r"^[a-zA-Z0-9-]+$", mime_type.lang):
+        tags = mime_type.lang.split(",")
+        if not all(re.fullmatch(r"[a-zA-Z0-9-]+", tag) for tag in tags):
             return False
 
     return True

--- a/src/gopher_mcp/ratelimit.py
+++ b/src/gopher_mcp/ratelimit.py
@@ -11,12 +11,22 @@ via ``GOPHER_REQUESTS_PER_MINUTE`` / ``GEMINI_REQUESTS_PER_MINUTE``.
 """
 
 import asyncio
+import math
 import time
 from collections.abc import Awaitable, Callable
 
 import structlog
 
 logger = structlog.get_logger(__name__)
+
+# Upper bound on a single SLOW_DOWN (status-44) backoff. The Gemini spec lets a
+# server name any number of seconds to wait, but the meta is attacker-controlled:
+# an unclamped value (notably ``inf``) makes ``acquire`` sleep effectively
+# forever while holding the per-client/batch concurrency semaphore, hanging every
+# later fetch -- and the penalty persists in ``_next_allowed``, poisoning the
+# host. Cap it so a server can still ask us to slow down, but only within a
+# bounded window (matches the configurable request-timeout ceiling).
+MAX_PENALTY_SECONDS = 300.0
 
 
 class RateLimiter:
@@ -90,10 +100,23 @@ class RateLimiter:
     def penalize(self, host: str, seconds: float) -> None:
         """Back off all requests to ``host`` for at least ``seconds``.
 
-        Used to honour a Gemini status-44 (SLOW_DOWN) response.
+        Used to honour a Gemini status-44 (SLOW_DOWN) response. ``seconds`` is
+        server-controlled, so it is sanitized: a non-finite value (``inf``/NaN)
+        is rejected and anything over ``MAX_PENALTY_SECONDS`` is clamped, so a
+        malicious server cannot pin the host (and a held semaphore slot) forever.
         """
+        seconds = float(seconds)
+        if not math.isfinite(seconds) and seconds == float("inf"):
+            # An explicit "wait forever" is treated as the maximum bounded wait.
+            seconds = MAX_PENALTY_SECONDS
+        elif not math.isfinite(seconds):
+            # NaN (or -inf): not a meaningful backoff -- ignore rather than
+            # writing a value that would wedge the reservation.
+            return
+        seconds = min(max(seconds, 0.0), MAX_PENALTY_SECONDS)
+        if seconds <= 0.0:
+            return
+
         now = self._clock()
-        self._next_allowed[host] = max(
-            self._next_allowed.get(host, 0.0), now + float(seconds)
-        )
+        self._next_allowed[host] = max(self._next_allowed.get(host, 0.0), now + seconds)
         logger.debug("Backing off host after slow-down", host=host, seconds=seconds)

--- a/task.py
+++ b/task.py
@@ -96,7 +96,9 @@ class TaskRunner:
                 "category": "Code Quality",
             },
             "typecheck": {
-                "cmd": "mypy src/ --ignore-missing-imports",
+                # Match CI's `mypy src` (no --ignore-missing-imports, which
+                # would hide missing-stub errors locally that CI still fails on).
+                "cmd": "mypy src",
                 "desc": "Run mypy type checking",
                 "category": "Code Quality",
             },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,17 @@
 
 import structlog
 
-from gopher_mcp.config import ServerConfig, configure_logging
+from gopher_mcp.config import AppConfig, ServerConfig, configure_logging
+
+
+def test_stray_unprefixed_env_var_does_not_crash_startup(monkeypatch):
+    """A bare GOPHER/GEMINI/SERVER env var set by unrelated tooling must not be
+    misread as the nested config object and crash AppConfig() at startup."""
+    monkeypatch.setenv("GOPHER", "some-unrelated-value")
+    monkeypatch.setenv("SERVER", "another-value")
+    cfg = AppConfig()  # must not raise
+    assert cfg.gopher.max_response_size == 1048576
+    assert cfg.server.log_level == "INFO"
 
 
 def test_configure_logging_writes_application_logs_to_file(tmp_path):

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -340,6 +340,36 @@ class TestGeminiClientFetch:
             assert result.error["code"] == "INVALID_REQUEST"
             assert "Invalid URL" in result.error["message"]
 
+    async def test_malformed_server_response_is_protocol_error_not_invalid_request(
+        self,
+    ):
+        """A server-side protocol fault (e.g. missing CRLF, empty response) must
+        surface as PROTOCOL_ERROR, not INVALID_REQUEST -- the latter wrongly
+        tells the model its own URL was malformed."""
+        from gopher_mcp.gemini_parse import GeminiProtocolError
+
+        client = GeminiClient()
+        mock_parsed_url = Mock()
+        mock_parsed_url.host = "example.com"
+        mock_parsed_url.port = 1965
+        mock_parsed_url.path = "/"
+        mock_parsed_url.query = None
+
+        with (
+            patch("gopher_mcp.gemini_client.parse_gemini_url") as mock_parse,
+            patch.object(client, "_fetch_content") as mock_fetch,
+        ):
+            mock_parse.return_value = mock_parsed_url
+            mock_fetch.side_effect = GeminiProtocolError(
+                "Invalid response format: missing CRLF"
+            )
+
+            result = await client.fetch("gemini://example.com/")
+
+            assert isinstance(result, GeminiErrorResult)
+            assert result.error["code"] == "PROTOCOL_ERROR"
+            assert "missing CRLF" in result.error["message"]
+
     @pytest.mark.asyncio
     async def test_fetch_security_violation(self):
         """Test fetch with security violation."""

--- a/tests/test_gemini_status.py
+++ b/tests/test_gemini_status.py
@@ -339,6 +339,21 @@ class TestValidateGeminiMimeType:
         mime = GeminiMimeType(type="text", subtype="gemini", lang="en@US")
         assert validate_gemini_mime_type(mime) is False
 
+    def test_comma_separated_language_list(self):
+        """The Gemini spec allows a comma-separated list of BCP47 tags in the
+        lang parameter (e.g. `lang=en,fr`); rejecting it discards the whole
+        MIME type (including the declared charset) downstream."""
+        mime = GeminiMimeType(type="text", subtype="gemini", lang="en,fr")
+        assert validate_gemini_mime_type(mime) is True
+        mime = GeminiMimeType(type="text", subtype="gemini", lang="en-US,fr-CA,de")
+        assert validate_gemini_mime_type(mime) is True
+
+    def test_malformed_language_list_is_rejected(self):
+        """A trailing/empty tag in the list is still malformed."""
+        for bad in ("en,", ",fr", "en,,fr"):
+            mime = GeminiMimeType(type="text", subtype="gemini", lang=bad)
+            assert validate_gemini_mime_type(mime) is False
+
 
 class TestProcessGeminiResponse:
     """Test Gemini response processing."""

--- a/tests/test_gemini_tls.py
+++ b/tests/test_gemini_tls.py
@@ -222,6 +222,24 @@ class TestSendReceiveClose:
         await GeminiTLSClient().close(_conn(writer=writer))
 
     @pytest.mark.asyncio
+    async def test_close_is_time_bounded_when_peer_withholds_close_notify(self):
+        """A peer that never sends close_notify must not hang close() past the
+        grace period (which would add the OS TCP timeout to every request)."""
+
+        async def _never_returns() -> None:
+            await asyncio.Event().wait()  # blocks forever
+
+        writer = Mock()
+        writer.close = Mock()
+        writer.wait_closed = Mock(side_effect=_never_returns)
+        with patch("gopher_mcp.gemini_tls.CLOSE_TIMEOUT_SECONDS", 0.01):
+            # Must return promptly (well under any real TCP timeout) and not raise.
+            await asyncio.wait_for(
+                GeminiTLSClient().close(_conn(writer=writer)), timeout=1.0
+            )
+        writer.close.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_receive_reads_until_eof(self):
         reader = asyncio.StreamReader()
         reader.feed_data(b"20 text/gemini\r\nHello")

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from gopher_mcp.ratelimit import RateLimiter
+from gopher_mcp.ratelimit import MAX_PENALTY_SECONDS, RateLimiter
 
 
 class _FakeClock:
@@ -65,6 +65,37 @@ class TestRateLimiterAcquire:
         await rl.acquire("slow.example")
         sleep.assert_awaited_once()
         assert sleep.await_args.args[0] == pytest.approx(5.0)
+
+    async def test_penalize_clamps_an_unbounded_backoff(self):
+        """A malicious status-44 meta of `inf` (or a huge number) must NOT be
+        honoured verbatim: an unclamped penalty makes acquire() sleep forever
+        while holding the concurrency semaphore, hanging every later fetch."""
+        clock = _FakeClock(100.0)
+        sleep = AsyncMock()
+        rl = RateLimiter(0, clock=clock, sleep=sleep)
+        rl.penalize("evil.example", float("inf"))
+        await rl.acquire("evil.example")
+        sleep.assert_awaited_once()
+        waited = sleep.await_args.args[0]
+        assert waited == pytest.approx(MAX_PENALTY_SECONDS)
+
+    async def test_penalize_clamps_a_huge_finite_backoff(self):
+        clock = _FakeClock(100.0)
+        sleep = AsyncMock()
+        rl = RateLimiter(0, clock=clock, sleep=sleep)
+        rl.penalize("evil.example", 10_000_000.0)
+        await rl.acquire("evil.example")
+        assert sleep.await_args.args[0] == pytest.approx(MAX_PENALTY_SECONDS)
+
+    async def test_penalize_ignores_non_finite_nan(self):
+        """A NaN penalty must not poison the host (nan comparisons are false,
+        which would otherwise wedge the reservation)."""
+        clock = _FakeClock(100.0)
+        sleep = AsyncMock()
+        rl = RateLimiter(0, clock=clock, sleep=sleep)
+        rl.penalize("evil.example", float("nan"))
+        await rl.acquire("evil.example")
+        sleep.assert_not_awaited()
 
     async def test_stale_host_entries_are_swept_when_throttling(self):
         """With throttling enabled, hosts visited once must not accumulate


### PR DESCRIPTION
End-to-end review follow-ups. Addresses the highest-value, low-risk findings from a full-codebase review; more involved items (see "Deferred" below) are left for focused follow-ups.

## Security / correctness

- **Clamp the server-controlled Gemini `SLOW_DOWN` (status 44) backoff** — *the one remotely-exploitable issue.* A malicious server replying `44 inf` (or a huge number) made `RateLimiter.penalize` store `now + inf`, and `acquire()` then `await asyncio.sleep(inf)` **outside any deadline** while holding the concurrency semaphore — hanging every later fetch to that host and, with `max_concurrent_requests` set, deadlocking the whole client. The penalty is now sanitized (non-finite rejected) and capped at `MAX_PENALTY_SECONDS`.
- **`PROTOCOL_ERROR` for server-side faults** — `parse_gemini_response` raised plain `ValueError` for malformed *server* responses (missing CRLF, over-long meta, bad status, empty response), which collapsed to `INVALID_REQUEST` and told the model *its* URL was wrong. New `GeminiProtocolError` (a `ValueError` subclass, so callers/tests are unaffected) maps to a distinct `PROTOCOL_ERROR`.
- **Accept spec-valid comma-separated `lang`** (e.g. `lang=en,fr`) — rejecting it failed `validate_gemini_mime_type`, which discarded the entire MIME type *including the declared charset*, producing mojibake / gemtext misclassification.
- **Time-bound the TLS close handshake** — a peer withholding `close_notify` could add the OS TCP timeout (~30s+) to every request past the deadline (`close()` runs in `finally`). Now capped at `CLOSE_TIMEOUT_SECONDS`.
- **Stop a stray unprefixed `GOPHER`/`GEMINI`/`SERVER` env var from crashing startup** — `AppConfig` misread it as the nested config object and raised `SettingsError`.

## Release / CI hygiene

- **`prepare-release.py`**: the unanchored `version = "..."` regex also rewrote `target-version`, `python_version`, and `minversion` in `pyproject.toml` (breaking ruff/mypy/pytest config on every scripted bump). Now anchored + first-match-only, and it also updates `server.json` (the release workflow hard-fails if it drifts but nothing updated it).
- **`uv sync --locked`** in all CI/release/publish jobs — a stale lockfile is now a loud failure instead of a silent re-resolve.
- **Release notes**: dropped the `head -n -1` that truncated the last line of every changelog section (v0.4.3's published notes ended mid-sentence).
- **Publish workflow**: removed the no-op `pypi` dispatch target (it built, reported success, and published nothing).
- **Dependabot**: added the `docker` ecosystem so the base image gets CVE-bump PRs.
- **docs.yml**: redeploy on `src/**` so the mkdocstrings API reference can't drift.
- **mypy**: aligned the local `task typecheck` with CI (dropped `--ignore-missing-imports`).

## Tests

Added coverage for each behavioral fix: SLOW_DOWN clamp (inf / huge / NaN), `PROTOCOL_ERROR` mapping, comma-separated `lang`, time-bounded TLS close, and the stray-env-var startup case. Full suite: **705 passed, 93.8% coverage**; ruff + ruff-format + mypy clean.

## Deferred (need a decision or a larger change — not in this PR)

- **Gemini binary bodies return full base64** (contradicts the `SERVER_INSTRUCTIONS` "metadata only" promise and Gopher's behavior). Genuine product decision — change behavior to metadata-only vs. fix the wording vs. make it configurable.
- Blocking `flock`/`fsync` (TOFU) and per-request SSL-context rebuild on the event loop; Gopher menu parser materializing the full list before truncating; per-line gemtext preformat metadata bloat; Gopher protocol fidelity (latin-1 selector round-trip, `URL:`/hURL links, un-dot-stuffing unframed text).