### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server's documented "binary bodies are returned as metadata only" contract; a
   1 MB body previously shipped ~1.4M base64 characters. Re-fetch the resource
   directly if the raw bytes are needed.
+- Gemtext preformat (code-block) content lines no longer repeat a per-line
+  metadata dict (plus duplicated `alt_text`/`language`); block-level metadata is
+  kept on the opening ` ``` ` toggle line only. This roughly thirded the
+  serialized size of code blocks sent to the model. Attribute access is
+  unchanged; only the serialized output is leaner.
+- The Gopher menu parser now stops once the item cap (`max_menu_items`) is
+  reached instead of building the entire directory before slicing, so a 1 MB
+  directory no longer materialises tens of thousands of model objects to keep a
+  small slice. Truncation is still flagged on the result.
 - Release/CI hygiene: `prepare-release.py` now bumps the version with an anchored
   match (no longer corrupting `target-version` / `python_version` / `minversion`
   in `pyproject.toml`) and also updates `server.json`; GitHub release notes no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Gopher menu items using the hURL web-link convention (a `URL:<target>`
+  selector, typically on a type-`h` item) now expose the real destination as
+  `next_url` instead of a `gopher://` URL pointing back at the gopher host, so
+  web/gemini links on real-world menus are followable.
+- Gopher text-mode un-dot-stuffing (`..` → `.`) is now applied only when the
+  RFC 1436 `.` terminator is actually present. An unframed document (no
+  terminator) is returned verbatim, so a literal leading `..` is no longer
+  corrupted to `.`.
 - A server-side Gemini protocol fault (missing CRLF, over-long meta, bad status
   line, empty response) now returns a distinct `PROTOCOL_ERROR` instead of
   `INVALID_REQUEST`, so the model is told the server misbehaved rather than that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-11
+
 ### Security
 
 - A malicious Gemini server can no longer hang the client with an unbounded
@@ -442,7 +444,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extensive test suite with >90% coverage
 - Complete documentation and examples
 
-[Unreleased]: https://github.com/cameronrye/gopher-mcp/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/cameronrye/gopher-mcp/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/cameronrye/gopher-mcp/compare/v0.4.3...v0.5.0
 [0.4.1]: https://github.com/cameronrye/gopher-mcp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/cameronrye/gopher-mcp/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/cameronrye/gopher-mcp/compare/v0.2.2...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reached instead of building the entire directory before slicing, so a 1 MB
   directory no longer materialises tens of thousands of model objects to keep a
   small slice. Truncation is still flagged on the result.
+- Client-certificate Gemini requests now reuse a per-certificate TLS client
+  (and its SSL context) instead of rebuilding it on every request, so the system
+  CA bundle load and cert/key PEM reads — blocking work that ran on the event
+  loop — happen once per certificate rather than per fetch.
 - Release/CI hygiene: `prepare-release.py` now bumps the version with an anchored
   match (no longer corrupting `target-version` / `python_version` / `minversion`
   in `pyproject.toml`) and also updates `server.json`; GitHub release notes no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Gemini binary success responses now return metadata only (size + detected
+  MIME type) as a new `binary` result kind, instead of base64-inlining the full
+  body into the model's context. This matches the Gopher binary path and the
+  server's documented "binary bodies are returned as metadata only" contract; a
+  1 MB body previously shipped ~1.4M base64 characters. Re-fetch the resource
+  directly if the raw bytes are needed.
 - Release/CI hygiene: `prepare-release.py` now bumps the version with an anchored
   match (no longer corrupting `target-version` / `python_version` / `minversion`
   in `pyproject.toml`) and also updates `server.json`; GitHub release notes no

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -219,7 +219,8 @@ field. See [Data Models](reference/models.md) for the complete field definitions
 | `kind` | Type | Returned for |
 |--------|------|--------------|
 | `gemtext` | [`GeminiGemtextResult`][gopher_mcp.models.GeminiGemtextResult] | `text/gemini` content, parsed into a [`GemtextDocument`][gopher_mcp.models.GemtextDocument] of [`GemtextLine`][gopher_mcp.models.GemtextLine] items |
-| `success` | [`GeminiSuccessResult`][gopher_mcp.models.GeminiSuccessResult] | Other success responses (status 20-29); the MIME type is a [`GeminiMimeType`][gopher_mcp.models.GeminiMimeType] |
+| `success` | [`GeminiSuccessResult`][gopher_mcp.models.GeminiSuccessResult] | Textual success responses (status 20-29); the MIME type is a [`GeminiMimeType`][gopher_mcp.models.GeminiMimeType] |
+| `binary` | [`GeminiBinaryResult`][gopher_mcp.models.GeminiBinaryResult] | Binary success responses — metadata only (size + MIME type), no raw bytes |
 | `input` | [`GeminiInputResult`][gopher_mcp.models.GeminiInputResult] | Input prompts (status 10-11) — answer with the `gemini_fetch` `input` parameter |
 | `redirect` | [`GeminiRedirectResult`][gopher_mcp.models.GeminiRedirectResult] | Redirects (status 30-31) |
 | `error` | [`GeminiErrorResult`][gopher_mcp.models.GeminiErrorResult] | Errors (status 40-59) |

--- a/docs/gemini-support.md
+++ b/docs/gemini-support.md
@@ -86,7 +86,7 @@ For `text/gemini` content, returns a structured document:
 
 #### GeminiSuccessResult
 
-For other content types (text, binary, etc.):
+For non-gemtext **text** content (e.g. `text/plain`):
 
 ```json
 {
@@ -101,6 +101,27 @@ For other content types (text, binary, etc.):
   },
   "content": "Plain text content here",
   "size": 23
+}
+```
+
+#### GeminiBinaryResult
+
+For binary content, only metadata is returned — the raw bytes are **not**
+inlined (a 1 MB body would be ~1.4M base64 characters of context). Re-fetch the
+resource directly if you need the bytes.
+
+```json
+{
+  "kind": "binary",
+  "mime_type": {
+    "full_type": "image/png",
+    "main_type": "image",
+    "sub_type": "png",
+    "is_text": false,
+    "is_gemtext": false
+  },
+  "size": 1048576,
+  "note": "Binary content not returned to preserve context"
 }
 ```
 

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -28,6 +28,8 @@ recipes, see the [API Reference](../api-reference.md).
 
 ::: gopher_mcp.models.GeminiSuccessResult
 
+::: gopher_mcp.models.GeminiBinaryResult
+
 ::: gopher_mcp.models.GeminiGemtextResult
 
 ::: gopher_mcp.models.GeminiInputResult

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gopher-mcp"
-version = "0.4.3"
+version = "0.5.0"
 description = "A cross-platform Model Context Protocol (MCP) server for browsing Gopher and Gemini resources"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.cameronrye/gopher-mcp",
   "description": "MCP server for browsing Gopher and Gemini protocol resources safely, with SSRF protection, TLS/TOFU, and structured JSON output.",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "repository": {
     "url": "https://github.com/cameronrye/gopher-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registry_type": "pypi",
       "registry_base_url": "https://pypi.org",
       "identifier": "gopher-mcp",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/gopher_mcp/gemini_client.py
+++ b/src/gopher_mcp/gemini_client.py
@@ -149,10 +149,40 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
                 client_certs_storage_path
             )
 
+        # Cache of TLS clients bound to a client certificate, keyed by
+        # (cert_path, key_path). Each holds a lazily-built SSL context, so the
+        # system CA bundle load + cert/key PEM reads happen once per cert pair
+        # instead of on every client-cert request (blocking work on the loop).
+        self._client_cert_tls_clients: dict[tuple[str, str], GeminiTLSClient] = {}
+
         # LRU cache (get/put behaviour lives in TTLCacheMixin). The element type
         # is inherited from the mixin annotation; only the entry class differs.
         self._cache = OrderedDict()
         self._cache_entry_cls = GeminiCacheEntry
+
+    def _tls_client_for_cert(self, cert_path: str, key_path: str) -> GeminiTLSClient:
+        """Return a TLS client bound to a client certificate, cached per pair.
+
+        Building the client (and its SSL context) reloads the system CA bundle
+        and reads the cert/key PEMs from disk; doing that on every client-cert
+        request was blocking work on the event loop. Cache by (cert, key) path so
+        it is paid once. Concurrent first-use may briefly build two clients (last
+        write wins) -- both are valid, so no lock is needed.
+        """
+        cache_key = (cert_path, key_path)
+        client = self._client_cert_tls_clients.get(cache_key)
+        if client is None:
+            base = self.tls_client.config
+            cfg = TLSConfig(
+                min_version=base.min_version,
+                verify_mode=base.verify_mode,
+                client_cert_path=cert_path,
+                client_key_path=key_path,
+                timeout_seconds=base.timeout_seconds,
+            )
+            client = GeminiTLSClient(cfg)
+            self._client_cert_tls_clients[cache_key] = client
+        return client
 
     def _validate_security(self, parsed_url: GeminiURL) -> None:
         """Validate security constraints for a Gemini request.
@@ -416,35 +446,22 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
                         cert_path=client_cert_path,
                     )
 
-            # Update TLS config with client certificate if available
-            tls_config = self.tls_client.config
+            # Pick the TLS client: a client-cert-bound one (whose SSL context is
+            # built and cached once per cert pair) when a cert applies to this
+            # scope, otherwise the shared default client. A single connect call
+            # then serves both paths.
             if client_cert_path and client_key_path:
-                # Create a new TLS config with client certificate
-                from .gemini_tls import TLSConfig
-
-                tls_config = TLSConfig(
-                    min_version=tls_config.min_version,
-                    verify_mode=tls_config.verify_mode,
-                    client_cert_path=client_cert_path,
-                    client_key_path=client_key_path,
-                    timeout_seconds=tls_config.timeout_seconds,
-                )
-                # Create temporary TLS client with client certificate
-                temp_tls_client = GeminiTLSClient(tls_config)
-                connection, connection_info = await temp_tls_client.connect(
-                    parsed_url.host,
-                    parsed_url.port,
-                    timeout=self.timeout_seconds,
-                    connect_ip=connect_ip,
+                tls_client = self._tls_client_for_cert(
+                    client_cert_path, client_key_path
                 )
             else:
-                # Use default TLS client
-                connection, connection_info = await self.tls_client.connect(
-                    parsed_url.host,
-                    parsed_url.port,
-                    timeout=self.timeout_seconds,
-                    connect_ip=connect_ip,
-                )
+                tls_client = self.tls_client
+            connection, connection_info = await tls_client.connect(
+                parsed_url.host,
+                parsed_url.port,
+                timeout=self.timeout_seconds,
+                connect_ip=connect_ip,
+            )
 
             # Validate certificate using TOFU if enabled (fail CLOSED).
             tofu_warning = None

--- a/src/gopher_mcp/gemini_parse.py
+++ b/src/gopher_mcp/gemini_parse.py
@@ -20,6 +20,7 @@ from .mime import (
     validate_gemini_mime_type,
 )
 from .models import (
+    GeminiBinaryResult,
     GeminiCertificateResult,
     GeminiErrorResult,
     GeminiFetchResponse,
@@ -378,7 +379,12 @@ def _process_success_response(
     *,
     max_rendered_chars: int = 0,
     denied_mime_types: "frozenset[str] | None" = None,
-) -> Union["GeminiSuccessResult", "GeminiGemtextResult", "GeminiErrorResult"]:
+) -> Union[
+    "GeminiSuccessResult",
+    "GeminiBinaryResult",
+    "GeminiGemtextResult",
+    "GeminiErrorResult",
+]:
     """Process success response (status 20-29).
 
     Args:
@@ -493,14 +499,14 @@ def _process_success_response(
                 with contextlib.suppress(ValueError):
                     mime_type = parse_gemini_mime_type(detected_type)
 
-        # Binary content is base64-encoded on serialization; flag it so the
-        # consumer knows how to interpret the content field.
-        binary_request_info = {**request_info, "content_encoding": "base64"}
-        return GeminiSuccessResult(
+        # Metadata only: do NOT return the raw bytes to the model. A 1 MB body is
+        # ~1.4M base64 chars (~350k tokens) of context for content the model
+        # can't render -- mirror the Gopher binary path and return size + type.
+        # `size` still reports the full original byte length.
+        return GeminiBinaryResult(
             mimeType=mime_type,
-            content=body,  # serialized as base64 (JSON-safe) by the model
             size=size,
-            requestInfo=binary_request_info,
+            requestInfo=request_info,
         )
 
 

--- a/src/gopher_mcp/gemtext.py
+++ b/src/gopher_mcp/gemtext.py
@@ -377,14 +377,18 @@ def parse_gemtext(content: str) -> "GemtextDocument":
                 )
                 continue
             else:
-                # Regular preformat content
-                metadata = _extract_preformat_metadata(current_alt_text, line_content)
+                # Regular preformat content. Block-level metadata (language and
+                # the code/data flags) belongs on the opening toggle line, not
+                # on every content line: repeating a 6-key metadata dict per line
+                # was pure serialized bloat (its ``line_count`` was always 1 and
+                # ``char_count`` just re-stated ``len(content)``). A content line
+                # carries only its verbatim text.
                 preformat_obj = GemtextPreformat(
                     content=line_content,
-                    alt_text=current_alt_text,
+                    alt_text=None,
                     is_toggle=False,
-                    language=metadata["language"],
-                    metadata=metadata,
+                    language=None,
+                    metadata={},
                 )
                 lines.append(
                     _create_gemtext_line(

--- a/src/gopher_mcp/gopher_client.py
+++ b/src/gopher_mcp/gopher_client.py
@@ -395,14 +395,19 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             Parsed menu result
         """
         content, _ = decode_gopher_text(raw)
-        items = parse_gopher_menu(content)
         # Cap the number of items handed to the LLM (distinct from the network
         # byte cap): a 1 MB directory can expand to tens of thousands of items,
         # each serialized to JSON, flooding the model context. 0 = unlimited.
-        truncated = False
-        if self.max_menu_items and len(items) > self.max_menu_items:
-            items = items[: self.max_menu_items]
-            truncated = True
+        # Parse at most one past the cap so we never materialise the whole
+        # directory yet can still tell whether it was truncated.
+        if self.max_menu_items:
+            items = parse_gopher_menu(content, max_items=self.max_menu_items + 1)
+            truncated = len(items) > self.max_menu_items
+            if truncated:
+                items = items[: self.max_menu_items]
+        else:
+            items = parse_gopher_menu(content)
+            truncated = False
         return MenuResult(items=items, truncated=truncated)
 
     def _process_text_response(self, raw: bytes) -> TextResult:

--- a/src/gopher_mcp/gopher_client.py
+++ b/src/gopher_mcp/gopher_client.py
@@ -49,6 +49,11 @@ def _strip_gopher_text_terminator(text: str) -> str:
     begin with ``..`` (the protocol doubles a leading ``.``). Only a terminator
     at the very end is removed -- servers that don't dot-stuff could otherwise
     have a legitimate mid-document ``.`` line truncated.
+
+    Un-dot-stuffing is applied ONLY when a terminator was actually present:
+    dot-stuffing is part of the period-termination framing, so an unframed
+    document (no terminator line) carries literal ``..`` content that must not
+    be collapsed to ``.``.
     """
     # Split on LF but keep any trailing '\r' on each line so CRLF is preserved
     # when we rejoin; remember a final newline so it survives the round-trip.
@@ -58,11 +63,13 @@ def _strip_gopher_text_terminator(text: str) -> str:
         lines = lines[:-1]
 
     # Drop a trailing terminator line ('.' possibly with a trailing '\r').
-    if lines and lines[-1].rstrip("\r") == ".":
+    had_terminator = bool(lines) and lines[-1].rstrip("\r") == "."
+    if had_terminator:
         lines = lines[:-1]
 
-    out = [line[1:] if line.startswith("..") else line for line in lines]
-    result = "\n".join(out)
+    if had_terminator:
+        lines = [line[1:] if line.startswith("..") else line for line in lines]
+    result = "\n".join(lines)
     if trailing_newline and result:
         result += "\n"
     return result

--- a/src/gopher_mcp/gopher_parse.py
+++ b/src/gopher_mcp/gopher_parse.py
@@ -128,15 +128,26 @@ def parse_menu_line(line: str) -> GopherMenuItem | None:
             if 0 <= candidate <= 65535:
                 port = candidate
 
-        # Construct the next URL. Percent-encode the selector (keeping '/')
-        # so a selector containing spaces, '?', '#' or '%' round-trips back
-        # through parse_gopher_url instead of mis-splitting into a bogus query.
-        # Bracket an IPv6 literal host so its colons don't collide with the
-        # port separator and break the re-parse.
-        next_url = (
-            f"gopher://{bracket_host(host)}:{port}/"
-            f"{item_type}{quote(selector, safe='/')}"
-        )
+        # hURL web-link convention: a selector of the form "URL:<target>"
+        # (overwhelmingly on type-h items, but recognised by selector prefix
+        # like real clients do) is a direct link to <target> -- usually an
+        # http/https/gemini URL -- NOT a gopher selector. Surface the real
+        # destination so the model can follow it, instead of a gopher:// URL
+        # that would just re-fetch the gopher host. Match the exact "URL:"
+        # prefix so an ordinary selector that merely starts with "url" is left
+        # alone.
+        if selector.startswith("URL:") and len(selector) > 4:
+            next_url = selector[4:]
+        else:
+            # Construct the next URL. Percent-encode the selector (keeping '/')
+            # so a selector containing spaces, '?', '#' or '%' round-trips back
+            # through parse_gopher_url instead of mis-splitting into a bogus
+            # query. Bracket an IPv6 literal host so its colons don't collide
+            # with the port separator and break the re-parse.
+            next_url = (
+                f"gopher://{bracket_host(host)}:{port}/"
+                f"{item_type}{quote(selector, safe='/')}"
+            )
 
         return GopherMenuItem(
             type=item_type,

--- a/src/gopher_mcp/gopher_parse.py
+++ b/src/gopher_mcp/gopher_parse.py
@@ -161,17 +161,24 @@ def parse_menu_line(line: str) -> GopherMenuItem | None:
         return None
 
 
-def parse_gopher_menu(content: str) -> list[GopherMenuItem]:
+def parse_gopher_menu(
+    content: str, max_items: int | None = None
+) -> list[GopherMenuItem]:
     """Parse a complete Gopher menu response.
 
     Args:
         content: Raw menu content from Gopher server
+        max_items: Stop after constructing this many items (None = unlimited).
+            A 1 MB directory can hold tens of thousands of lines; without a cap
+            every one becomes a model object even though the caller only keeps a
+            slice. The caller passes its display cap + 1 so it can still detect
+            (and flag) truncation without materialising the whole directory.
 
     Returns:
-        List of parsed menu items
+        List of parsed menu items (at most ``max_items`` when set).
 
     """
-    items = []
+    items: list[GopherMenuItem] = []
 
     # Normalize all three RFC 1436 line endings (CRLF), bare LF and legacy
     # bare CR before splitting -- a CR-only server would otherwise collapse the
@@ -188,6 +195,8 @@ def parse_gopher_menu(content: str) -> list[GopherMenuItem]:
         item = parse_menu_line(line)
         if item:
             items.append(item)
+            if max_items is not None and len(items) >= max_items:
+                break
 
     return items
 

--- a/src/gopher_mcp/models.py
+++ b/src/gopher_mcp/models.py
@@ -1,6 +1,5 @@
 """Pydantic models for Gopher MCP data validation."""
 
-import base64
 from enum import Enum, IntEnum
 from typing import Any, Generic, Literal, TypeVar
 from urllib.parse import urlparse
@@ -8,7 +7,6 @@ from urllib.parse import urlparse
 from pydantic import (
     BaseModel,
     Field,
-    field_serializer,
     field_validator,
     model_serializer,
 )
@@ -366,32 +364,50 @@ class GeminiResponse(BaseModel):
 
 # Response result models following Gopher patterns
 class GeminiSuccessResult(BaseModel):
-    """Result model for successful Gemini responses."""
+    """Result model for a successful Gemini response carrying TEXT content.
+
+    Binary success responses use :class:`GeminiBinaryResult` (metadata only), so
+    ``content`` is always decoded text here.
+    """
 
     kind: Literal["success"] = "success"
     mime_type: GeminiMimeType = Field(
         ..., alias="mimeType", description="Content MIME type"
     )
-    content: str | bytes = Field(..., description="Response content")
+    content: str = Field(..., description="Decoded text response content")
     size: int = Field(..., ge=0, description="Content size in bytes")
     truncated: bool = Field(
         default=False,
-        description="True if text `content` was truncated to the render limit "
-        "(`size` still reports the full original size). Never set for binary.",
+        description="True if `content` was truncated to the render limit "
+        "(`size` still reports the full original size).",
     )
 
-    @field_serializer("content")
-    def _serialize_content(self, v: str | bytes) -> str:
-        """Base64-encode binary content so model_dump() stays JSON-serializable.
+    request_info: dict[str, Any] = Field(
+        default_factory=dict,
+        alias="requestInfo",
+        description="Information about the original request",
+    )
 
-        A status-20 binary response would otherwise carry raw bytes that fail
-        to serialize at the MCP boundary. ``content_encoding`` in request_info
-        signals when the content has been base64-encoded.
-        """
-        if isinstance(v, bytes):
-            return base64.b64encode(v).decode("ascii")
-        return v
 
+class GeminiBinaryResult(BaseModel):
+    """Result model for a successful BINARY Gemini response (metadata only).
+
+    Mirrors the Gopher :class:`BinaryResult`: the raw bytes are NOT returned to
+    the model. A 1 MB body is ~1.4M base64 characters (~350k tokens), so
+    inlining it would flood the context for content the model can't render
+    anyway. The consumer gets the size and detected MIME type and can fetch the
+    resource directly if it genuinely needs the bytes.
+    """
+
+    kind: Literal["binary"] = "binary"
+    mime_type: GeminiMimeType = Field(
+        ..., alias="mimeType", description="Detected content MIME type"
+    )
+    size: int = Field(..., ge=0, description="Content size in bytes")
+    note: str = Field(
+        default="Binary content not returned to preserve context",
+        description="Note about binary handling",
+    )
     request_info: dict[str, Any] = Field(
         default_factory=dict,
         alias="requestInfo",
@@ -692,6 +708,7 @@ class GeminiGemtextResult(BaseModel):
 # Union type for all possible Gemini fetch responses
 GeminiFetchResponse = (
     GeminiSuccessResult
+    | GeminiBinaryResult
     | GeminiGemtextResult
     | GeminiInputResult
     | GeminiRedirectResult

--- a/src/gopher_mcp/models.py
+++ b/src/gopher_mcp/models.py
@@ -551,6 +551,19 @@ class GemtextPreformat(BaseModel):
         default_factory=dict, description="Additional metadata"
     )
 
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: Any) -> dict[str, Any]:
+        """Drop null/empty fields on serialization.
+
+        Block-level metadata (alt_text/language/metadata) is populated only on
+        the opening toggle line; a content line then serializes to just its
+        ``content`` and ``is_toggle`` instead of repeating empty alt_text,
+        language and an empty metadata dict on every line. Attribute access is
+        unaffected; only the serialized dict is trimmed.
+        """
+        data: dict[str, Any] = handler(self)
+        return {k: v for k, v in data.items() if v is not None and v != {}}
+
 
 class GemtextLine(BaseModel):
     """Model for a single line in gemtext format."""

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -45,6 +45,17 @@ class TestGeminiClientInit:
         logged = str(mock_logger.warning.call_args).lower()
         assert "tofu" in logged or "unauthenticated" in logged
 
+    def test_tls_client_for_cert_is_cached_per_pair(self):
+        """The client-cert TLS client (and its SSL context) is built once per
+        (cert, key) pair, not rebuilt on every request."""
+        client = GeminiClient(tofu_enabled=False, client_certs_enabled=False)
+        a = client._tls_client_for_cert("/a.crt", "/a.key")
+        b = client._tls_client_for_cert("/a.crt", "/a.key")
+        assert a is b
+        assert a.config.client_cert_path == "/a.crt"
+        other = client._tls_client_for_cert("/b.crt", "/b.key")
+        assert other is not a
+
     def test_status_44_slow_down_penalizes_host(self):
         """A status-44 SLOW_DOWN backs the host off for the advertised seconds."""
         client = GeminiClient(tofu_enabled=False, client_certs_enabled=False)

--- a/tests/test_gemini_status.py
+++ b/tests/test_gemini_status.py
@@ -3,6 +3,7 @@
 import pytest
 
 from gopher_mcp.models import (
+    GeminiBinaryResult,
     GeminiCertificateResult,
     GeminiErrorResult,
     GeminiGemtextResult,
@@ -461,11 +462,12 @@ class TestProcessGeminiResponse:
             status=GeminiStatusCode.SUCCESS, meta="garbage-no-slash", body=png
         )
         result = process_gemini_response(response, "gemini://example.org/")
-        assert isinstance(result, GeminiSuccessResult)
+        assert isinstance(result, GeminiBinaryResult)
         assert result.mime_type.full_type == "image/png"
 
     def test_success_binary_response(self):
-        """Test success binary response processing."""
+        """A binary success returns metadata only (no inline bytes), mirroring
+        the Gopher binary path."""
         binary_data = b"\x89PNG\r\n\x1a\n"  # PNG header
         response = GeminiResponse(
             status=GeminiStatusCode.SUCCESS, meta="image/png", body=binary_data
@@ -473,9 +475,27 @@ class TestProcessGeminiResponse:
 
         result = process_gemini_response(response, "gemini://example.org/image.png")
 
-        assert isinstance(result, GeminiSuccessResult)
-        assert result.content == binary_data
+        assert isinstance(result, GeminiBinaryResult)
+        assert result.kind == "binary"
+        assert result.size == len(binary_data)
+        assert result.mime_type.full_type == "image/png"
         assert result.mime_type.is_text is False
+        # The raw bytes must NOT be present on the result.
+        assert "content" not in result.model_dump()
+
+    def test_success_binary_response_does_not_inline_large_bodies(self):
+        """A large binary body must not be base64-inlined into the result (the
+        bug this fixes shipped ~1.4M chars of context for a 1 MB image)."""
+        big = b"\x89PNG\r\n\x1a\n" + b"\x00" * 500_000
+        response = GeminiResponse(
+            status=GeminiStatusCode.SUCCESS, meta="image/png", body=big
+        )
+        result = process_gemini_response(response, "gemini://example.org/big.png")
+        assert isinstance(result, GeminiBinaryResult)
+        assert result.size == len(big)
+        dumped = result.model_dump()
+        # No field carries the encoded body; the whole result stays tiny.
+        assert len(str(dumped)) < 1000
 
     def test_temporary_redirect_response(self):
         """Test temporary redirect response processing."""
@@ -758,7 +778,8 @@ class TestProcessGeminiResponse:
         assert result.mime_type.charset == "latin-1"  # Should fallback to latin1
 
     def test_success_response_binary_detection(self):
-        """Test success response with binary content detection."""
+        """An octet-stream body is sniffed to a specific type and returned as
+        metadata only (no inline bytes)."""
         png_data = b"\x89PNG\r\n\x1a\n" + b"fake_png_data"
 
         response = GeminiResponse(
@@ -769,9 +790,9 @@ class TestProcessGeminiResponse:
 
         result = process_gemini_response(response, "gemini://example.org/image")
 
-        assert isinstance(result, GeminiSuccessResult)
+        assert isinstance(result, GeminiBinaryResult)
         assert result.mime_type.full_type == "image/png"
-        assert result.content == png_data
+        assert result.size == len(png_data)
 
     def test_success_response_invalid_mime_fallback(self):
         """An invalid MIME with non-binary content defaults to text/gemini."""

--- a/tests/test_gemini_utils.py
+++ b/tests/test_gemini_utils.py
@@ -537,6 +537,30 @@ class TestGemtextParsingRobustness:
         ]
         assert "code with trailing   " in pre_contents
 
+    def test_preformat_content_lines_serialize_lean(self):
+        """A code block must not repeat a 6-key metadata dict (plus duplicated
+        alt_text/language) on every content line -- that tripled the serialized
+        size of code blocks. Content lines serialize to just content+is_toggle."""
+        from gopher_mcp.utils import parse_gemtext
+
+        document = parse_gemtext("```python\nprint(1)\nprint(2)\n```")
+        dumped = document.model_dump()
+        content_lines = [
+            line
+            for line in dumped["lines"]
+            if line["type"] == "preformat" and line["preformat"]["is_toggle"] is False
+        ]
+        assert len(content_lines) == 2
+        for line in content_lines:
+            assert set(line["preformat"].keys()) == {"content", "is_toggle"}
+        # The opening toggle still carries the block-level language/metadata.
+        opening = next(
+            line
+            for line in dumped["lines"]
+            if line["type"] == "preformat" and line["preformat"]["is_toggle"] is True
+        )
+        assert opening["preformat"]["language"] == "python"
+
     def test_does_not_split_on_vertical_tab(self):
         from gopher_mcp.utils import parse_gemtext
 

--- a/tests/test_gopher_client.py
+++ b/tests/test_gopher_client.py
@@ -507,6 +507,27 @@ class TestResponseProcessing:
         assert item2.title == "Test Directory"
         assert item2.next_url == "gopher://example.com:70/1/testdir/"
 
+    def test_process_menu_response_caps_items_and_flags_truncation(self):
+        """Over-cap menus are sliced to max_menu_items with truncated=True, and
+        the parser stops early rather than building the whole directory."""
+        client = GopherClient(max_menu_items=3)
+        raw = (
+            "".join(
+                f"0File {i}\t/f{i}\texample.com\t70\r\n" for i in range(20)
+            ).encode()
+            + b".\r\n"
+        )
+        result = client._process_menu_response(raw)
+        assert len(result.items) == 3
+        assert result.truncated is True
+
+    def test_process_menu_response_not_truncated_when_under_cap(self):
+        client = GopherClient(max_menu_items=10)
+        raw = b"0Only\t/only\texample.com\t70\r\n.\r\n"
+        result = client._process_menu_response(raw)
+        assert len(result.items) == 1
+        assert result.truncated is False
+
     def test_process_menu_response_skips_terminator_and_blanks(self):
         """The '.' terminator and blank lines are not emitted as items."""
         client = GopherClient()

--- a/tests/test_gopher_client.py
+++ b/tests/test_gopher_client.py
@@ -570,6 +570,14 @@ class TestResponseProcessing:
         result = client._process_text_response(b"just text\nno terminator")
         assert result.text == "just text\nno terminator"
 
+    def test_process_text_response_unframed_does_not_undot_stuff(self):
+        """Un-dot-stuffing is part of the RFC 1436 period-termination framing.
+        Without a trailing '.' terminator the document is unframed, so a leading
+        '..' is literal content and must NOT be collapsed to '.'."""
+        client = GopherClient()
+        result = client._process_text_response(b"..literal dots\nplain text")
+        assert result.text == "..literal dots\nplain text"
+
     def test_process_menu_response_handles_cr_only_line_endings(self):
         """Legacy CR-only line separators are split, not merged into one line."""
         client = GopherClient()

--- a/tests/test_serialization_contract.py
+++ b/tests/test_serialization_contract.py
@@ -32,6 +32,13 @@ EXPECTED_KEYS: dict[str, set[str]] = {
         "truncated",
         "request_info",
     },
+    "GeminiBinaryResult": {
+        "kind",
+        "mime_type",
+        "size",
+        "note",
+        "request_info",
+    },
     "GeminiInputResult": {"kind", "prompt", "sensitive", "request_info"},
     "GeminiRedirectResult": {"kind", "new_url", "permanent", "request_info"},
     "GeminiErrorResult": {"kind", "error", "request_info"},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,6 +160,32 @@ class TestParseMenuLine:
         assert result.host == "error.host"
         assert result.port == 1
 
+    def test_hurl_web_link_selector(self):
+        """The hURL convention encodes a web link as a 'URL:<target>' selector
+        (usually on a type-h item). nextUrl must point at the real destination,
+        not a gopher:// URL aimed back at the gopher host."""
+        line = "hExample site\tURL:https://example.com/path\tgopher.host\t70"
+        result = parse_menu_line(line)
+
+        assert result is not None
+        assert result.type == "h"
+        assert result.selector == "URL:https://example.com/path"
+        assert result.next_url == "https://example.com/path"
+
+    def test_hurl_web_link_preserves_query_and_fragment(self):
+        line = "hSearch\tURL:gemini://example.org/q?a=b#frag\tgopher.host\t70"
+        result = parse_menu_line(line)
+        assert result is not None
+        assert result.next_url == "gemini://example.org/q?a=b#frag"
+
+    def test_non_hurl_selector_starting_with_url_text_is_not_a_web_link(self):
+        """Only an exact 'URL:' prefix triggers the hURL convention; a normal
+        selector that merely starts with 'url' stays a gopher selector."""
+        line = "0urls.txt\t/urls.txt\texample.com\t70"
+        result = parse_menu_line(line)
+        assert result is not None
+        assert result.next_url == "gopher://example.com:70/0/urls.txt"
+
     def test_empty_line(self):
         """Test parsing empty line."""
         result = parse_menu_line("")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -275,6 +275,15 @@ iThis is information\t\terror.host\t1
         result = parse_gopher_menu(content)
         assert len(result) == 0
 
+    def test_max_items_stops_early(self):
+        """max_items bounds how many items are constructed, so a huge directory
+        doesn't materialise tens of thousands of model objects to keep a slice."""
+        content = "".join(f"0File {i}\t/f{i}\texample.com\t70\n" for i in range(100))
+        result = parse_gopher_menu(content, max_items=5)
+        assert len(result) == 5
+        assert result[0].title == "File 0"
+        assert result[-1].title == "File 4"
+
     def test_menu_with_invalid_lines(self):
         """Test parsing menu with some invalid lines."""
         content = """1Valid\t/valid\texample.com\t70

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ wheels = [
 
 [[package]]
 name = "gopher-mcp"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Release **0.5.0**. Bundles the end-to-end review follow-ups and **re-lands the changes from #63**, which were orphaned when #62's branch was deleted on merge (GitHub closed #63 as "merged" into the deleted branch, so its commits never reached `main`). The four commits are cherry-picked here unchanged.

### Included

**Security**
- Clamp the server-controlled Gemini `SLOW_DOWN` (status 44) backoff — a `44 inf` reply can no longer hang/deadlock the client (#62).
- Time-bound the TLS close handshake (#62).

**Fixed**
- `PROTOCOL_ERROR` for malformed server responses instead of `INVALID_REQUEST` (#62).
- Accept spec-valid comma-separated `lang` (#62).
- Gopher hURL web links + framing-gated un-dot-stuffing (#63).
- Stray `GOPHER`/`GEMINI`/`SERVER` env var no longer crashes startup (#62).

**Changed**
- Gemini binary responses are now metadata-only (new `binary` result kind); `GeminiSuccessResult` is text-only (#63).
- Leaner gemtext code blocks and Gopher menu parsing (#63).
- Per-certificate TLS client caching (#63).
- Release/CI hygiene (#62).

### Release mechanics
- `pyproject.toml`, `server.json` (both fields), and `uv.lock` bumped to 0.5.0; version-consistency checks the release workflow enforces all pass locally.
- `CHANGELOG.md` `[Unreleased]` → `[0.5.0] - 2026-06-11`.
- Full suite: **716 passed, 94.2% coverage**; ruff/format/mypy clean.

Once this merges, tag `v0.5.0` triggers the PyPI publish + GitHub release.