### PR TITLE
feat: honour robots.txt and enable politeness limits by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,12 @@ repos:
           - types-requests
           - types-setuptools
           - pydantic>=2.5.0
-          - mcp>=1.0.0
+          # Without pydantic-settings the hook resolves BaseSettings to Any and
+          # reports every config class as "cannot subclass". Pin mcp to the
+          # version the project actually resolves: an unpinned floor let the
+          # hook install a different API shape than the code targets.
+          - pydantic-settings>=2.0.0
+          - mcp==1.27.2
           - structlog>=23.2.0
           - anyio>=4.0.0
         args: [--ignore-missing-imports, --explicit-package-bases]

--- a/README.md
+++ b/README.md
@@ -341,28 +341,34 @@ The server can be configured through environment variables for both protocols:
 
 ### Gopher Configuration
 
-| Variable                   | Description                    | Default         | Example                |
-| -------------------------- | ------------------------------ | --------------- | ---------------------- |
-| `GOPHER_MAX_RESPONSE_SIZE` | Maximum response size in bytes | `1048576` (1MB) | `2097152`              |
-| `GOPHER_TIMEOUT_SECONDS`   | Request timeout in seconds     | `30`            | `60`                   |
-| `GOPHER_CACHE_ENABLED`     | Enable response caching        | `true`          | `false`                |
-| `GOPHER_CACHE_TTL_SECONDS` | Cache time-to-live in seconds  | `300`           | `600`                  |
-| `GOPHER_MAX_CACHE_ENTRIES` | Max cached entries (LRU)       | `1000`          | `2000`                 |
-| `GOPHER_ALLOWED_HOSTS`     | Comma-separated allowed hosts  | `None` (all)    | `example.com,test.com` |
-| `GOPHER_ALLOW_LOCAL_HOSTS` | Permit loopback/private hosts  | `false`         | `true`                 |
+| Variable                         | Description                    | Default         | Example                |
+| -------------------------------- | ------------------------------ | --------------- | ---------------------- |
+| `GOPHER_MAX_RESPONSE_SIZE`       | Maximum response size in bytes | `1048576` (1MB) | `2097152`              |
+| `GOPHER_TIMEOUT_SECONDS`         | Request timeout in seconds     | `30`            | `60`                   |
+| `GOPHER_CACHE_ENABLED`           | Enable response caching        | `true`          | `false`                |
+| `GOPHER_CACHE_TTL_SECONDS`       | Cache time-to-live in seconds  | `300`           | `600`                  |
+| `GOPHER_MAX_CACHE_ENTRIES`       | Max cached entries (LRU)       | `1000`          | `2000`                 |
+| `GOPHER_ALLOWED_HOSTS`           | Comma-separated allowed hosts  | `None` (all)    | `example.com,test.com` |
+| `GOPHER_ALLOW_LOCAL_HOSTS`       | Permit loopback/private hosts  | `false`         | `true`                 |
+| `GOPHER_REQUESTS_PER_MINUTE`     | Per-host request cap (0 = off) | `60`            | `30`                   |
+| `GOPHER_MAX_CONCURRENT_REQUESTS` | Simultaneous fetches (0 = off) | `5`             | `2`                    |
+| `GOPHER_RESPECT_ROBOTS_TXT`      | Honour `/robots.txt`           | `false`         | `true`                 |
 
 ### Gemini Configuration
 
-| Variable                      | Description                        | Default         | Example                |
-| ----------------------------- | ---------------------------------- | --------------- | ---------------------- |
-| `GEMINI_MAX_RESPONSE_SIZE`    | Maximum response size in bytes     | `1048576` (1MB) | `2097152`              |
-| `GEMINI_TIMEOUT_SECONDS`      | Request timeout in seconds         | `30`            | `60`                   |
-| `GEMINI_CACHE_ENABLED`        | Enable response caching            | `true`          | `false`                |
-| `GEMINI_CACHE_TTL_SECONDS`    | Cache time-to-live in seconds      | `300`           | `600`                  |
-| `GEMINI_ALLOWED_HOSTS`        | Comma-separated allowed hosts      | `None` (all)    | `example.org,test.org` |
-| `GEMINI_ALLOW_LOCAL_HOSTS`    | Permit loopback/private hosts      | `false`         | `true`                 |
-| `GEMINI_TOFU_ENABLED`         | Enable TOFU certificate validation | `true`          | `false`                |
-| `GEMINI_CLIENT_CERTS_ENABLED` | Enable client certificate support  | `true`          | `false`                |
+| Variable                         | Description                        | Default         | Example                |
+| -------------------------------- | ---------------------------------- | --------------- | ---------------------- |
+| `GEMINI_MAX_RESPONSE_SIZE`       | Maximum response size in bytes     | `1048576` (1MB) | `2097152`              |
+| `GEMINI_TIMEOUT_SECONDS`         | Request timeout in seconds         | `30`            | `60`                   |
+| `GEMINI_CACHE_ENABLED`           | Enable response caching            | `true`          | `false`                |
+| `GEMINI_CACHE_TTL_SECONDS`       | Cache time-to-live in seconds      | `300`           | `600`                  |
+| `GEMINI_ALLOWED_HOSTS`           | Comma-separated allowed hosts      | `None` (all)    | `example.org,test.org` |
+| `GEMINI_ALLOW_LOCAL_HOSTS`       | Permit loopback/private hosts      | `false`         | `true`                 |
+| `GEMINI_TOFU_ENABLED`            | Enable TOFU certificate validation | `true`          | `false`                |
+| `GEMINI_CLIENT_CERTS_ENABLED`    | Enable client certificate support  | `true`          | `false`                |
+| `GEMINI_REQUESTS_PER_MINUTE`     | Per-host request cap (0 = off)     | `60`            | `30`                   |
+| `GEMINI_MAX_CONCURRENT_REQUESTS` | Simultaneous fetches (0 = off)     | `5`             | `2`                    |
+| `GEMINI_RESPECT_ROBOTS_TXT`      | Honour `/robots.txt`               | `false`         | `true`                 |
 
 > **SSRF protection:** by default both tools reject targets that resolve to loopback,
 > link-local (including cloud metadata `169.254.169.254`), or private/RFC1918 addresses.
@@ -370,8 +376,8 @@ The server can be configured through environment variables for both protocols:
 > deliberately need to reach local hosts (e.g. testing a server on localhost).
 
 The tables above cover the most common settings. Additional options include cache
-sizing (`*_MAX_CACHE_ENTRIES`), per-host rate limiting (`*_REQUESTS_PER_MINUTE`),
-concurrency caps (`*_MAX_CONCURRENT_REQUESTS`), rendered-output limits
+sizing (`*_MAX_CACHE_ENTRIES`), robots policy caching (`*_ROBOTS_CACHE_TTL_SECONDS`,
+`*_ROBOTS_HONOR_AI_TOKENS`), rendered-output limits
 (`*_MAX_RENDERED_CHARS`), Gemini TOFU/certificate storage paths
 (`GEMINI_TOFU_STORAGE_PATH`, `GEMINI_CLIENT_CERTS_STORAGE_PATH`), MIME filtering
 (`GEMINI_DENIED_MIME_TYPES`), and server/logging settings under the `GOPHER_MCP_`
@@ -398,6 +404,86 @@ export GEMINI_ALLOWED_HOSTS="geminiprotocol.net,warmedal.se"
 # Run with custom config
 uv run task serve
 ```
+
+## Network Etiquette
+
+Gopherspace and Geminispace are served largely by individuals running small
+machines. This server is built to be a guest there.
+
+### What this tool does and does not do
+
+`gopher-mcp` fetches a resource when someone asks their assistant for it, and
+returns the content to that conversation. It does **not** train on what it
+fetches, archive it, rehost it, or make it searchable. It does not follow links
+on its own: every URL it retrieves was named by the caller.
+
+Neither protocol has a user-agent field, so nothing identifies this client on
+the wire and a server cannot recognise or block it by name. That is a property
+of Gopher and Gemini, not a choice made here. What it does do, when robots
+checking is enabled below, is honour rules written against the token
+`gopher-mcp`, so an operator who wants to single it out has a way to.
+
+### Rate limiting
+
+Both clients space out requests to the same host and cap how many fetches run at
+once. Unlike earlier versions, **these are on by default**: one request per
+second per host (`*_REQUESTS_PER_MINUTE=60`) and five concurrent fetches
+(`*_MAX_CONCURRENT_REQUESTS=5`). Set either to `0` to disable it. A Gemini server
+answering `44 SLOW_DOWN` is always honoured regardless of these settings.
+
+### Robot exclusion (`robots.txt`)
+
+Set `GOPHER_RESPECT_ROBOTS_TXT=true` / `GEMINI_RESPECT_ROBOTS_TXT=true` to have
+the server fetch `/robots.txt` from the host root and honour it before
+retrieving anything. It is off by default because it costs an extra round-trip
+per host, and because a host serving a blanket `Disallow: /` would otherwise
+silently break an existing deployment. Policies are cached per host for 24 hours
+(`*_ROBOTS_CACHE_TTL_SECONDS`).
+
+Which convention applies depends on the protocol:
+
+- **Gemini** follows the official [companion specification][gemini-robots],
+  which defines the virtual agents `archiver`, `indexer`, `researcher` and
+  `webproxy`. This server matches `gopher-mcp`, `webproxy`, `indexer` and `*`.
+  It does not claim `archiver` or `researcher`: nothing here retains content,
+  and `researcher` is defined for tools that operate without surfacing what they
+  fetch.
+- **Gopher** follows the convention [Veronica-2 documents][veronica]. This
+  server matches `gopher-mcp` and `*`. It does not claim `veronica`, which
+  belongs to Floodgap's indexer.
+
+Both use the original 1994 `robots.txt` grammar rather than RFC 9309, so only
+`#`, `User-agent:` and `Disallow:` are recognised and every other field,
+including `Allow:`, is ignored. This matters: an RFC 9309 parser would act on
+`Allow:` lines that authors on these networks expect to be dropped, making it
+_more_ permissive than intended.
+
+By default the server also honours rules naming AI crawler tokens such as
+`ClaudeBot`, `GPTBot` and `CCBot` (`*_ROBOTS_HONOR_AI_TOKENS`). These are not
+part of either protocol's convention, but an operator who wrote one meant "no
+LLM tooling", and that is the request being made.
+
+Two known limitations, both documented rather than papered over:
+
+- **Gopher fails open.** The protocol has no status codes, so a missing
+  selector, an error document and an empty file are indistinguishable on the
+  wire. RFC 9309 §2.3.1.4 would have an unreachable policy deny everything,
+  which would block most of Gopherspace. Instead the parser is lenient: content
+  that yields no `User-agent:` group imposes no rules. Gemini, which does have
+  status codes, fails closed on a temporary (4x) failure and treats `51 NOT
+FOUND` as "no policy".
+- **Gopher path rules are best-effort.** A Gopher URI carries the item type as
+  the first path character, so `gopher://host/1/archive` has the URI path
+  `/1/archive` but the on-wire selector `/archive`. Rules are tested against both
+  spellings, but `Disallow: /` is the only form guaranteed to behave the way its
+  author expects.
+
+There is no per-directory or per-user `robots.txt`. Neither protocol convention
+nor RFC 9309 §2.3 defines one; on shared hosts the established pattern is a
+single file at the root using path prefixes.
+
+[gemini-robots]: https://geminiprotocol.net/docs/companion/robots.gmi
+[veronica]: gopher://gopher.floodgap.com/0/v2/help/indexer
 
 ## Contributing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,8 +83,11 @@ Provide environment variables through your MCP client (e.g. Claude Desktop):
 | `GOPHER_MAX_SEARCH_LENGTH` | Integer | `256` | Maximum search query length. |
 | `GOPHER_MAX_RENDERED_CHARS` | Integer | `50000` | Maximum characters of rendered text returned to the model (longer output is truncated and flagged). |
 | `GOPHER_MAX_MENU_ITEMS` | Integer | `1000` | Maximum Gopher menu items returned to the model (`0` = unlimited; larger menus are truncated and flagged). |
-| `GOPHER_REQUESTS_PER_MINUTE` | Float | `0` (off) | Per-host outbound rate limit. |
-| `GOPHER_MAX_CONCURRENT_REQUESTS` | Integer | `0` (unlimited) | Maximum concurrent requests. |
+| `GOPHER_REQUESTS_PER_MINUTE` | Float | `60` | Per-host outbound rate limit; `0` disables it. |
+| `GOPHER_MAX_CONCURRENT_REQUESTS` | Integer | `5` | Maximum concurrent requests; `0` is unlimited. |
+| `GOPHER_RESPECT_ROBOTS_TXT` | Boolean | `false` | Fetch and honour `/robots.txt` from the host root, per the convention Veronica-2 documents. Fails open: Gopher has no status codes, so an unreachable policy cannot be distinguished from an absent one. |
+| `GOPHER_ROBOTS_CACHE_TTL_SECONDS` | Integer | `86400` | Lifetime of a cached robots policy (max `604800`). |
+| `GOPHER_ROBOTS_HONOR_AI_TOKENS` | Boolean | `true` | Also honour rules naming AI crawler tokens (`ClaudeBot`, `GPTBot`, `CCBot`, ...). |
 
 ## Gemini Protocol Configuration (`GEMINI_`)
 
@@ -104,8 +107,11 @@ Provide environment variables through your MCP client (e.g. Claude Desktop):
 | `GEMINI_CLIENT_CERTS_ENABLED` | Boolean | `true` | Enable automatic per-host client certificates. |
 | `GEMINI_CLIENT_CERTS_STORAGE_PATH` | Directory path | `~/.gemini/certs/` | Client-certificate storage directory. |
 | `GEMINI_MAX_RENDERED_CHARS` | Integer | `50000` | Maximum characters of rendered text returned to the model (longer output is truncated and flagged). |
-| `GEMINI_REQUESTS_PER_MINUTE` | Float | `0` (off) | Per-host outbound rate limit. Gemini status 44 SLOW_DOWN is always honoured. |
-| `GEMINI_MAX_CONCURRENT_REQUESTS` | Integer | `0` (unlimited) | Maximum concurrent requests. |
+| `GEMINI_REQUESTS_PER_MINUTE` | Float | `60` | Per-host outbound rate limit; `0` disables it. Gemini status 44 SLOW_DOWN is always honoured. |
+| `GEMINI_MAX_CONCURRENT_REQUESTS` | Integer | `5` | Maximum concurrent requests; `0` is unlimited. |
+| `GEMINI_RESPECT_ROBOTS_TXT` | Boolean | `false` | Fetch and honour `/robots.txt` from the capsule root, per the Gemini companion specification (virtual agents `webproxy` and `indexer`, plus `*`). Fails closed on a temporary (4x) failure; `51 NOT FOUND` means no policy. |
+| `GEMINI_ROBOTS_CACHE_TTL_SECONDS` | Integer | `86400` | Lifetime of a cached robots policy (max `604800`). |
+| `GEMINI_ROBOTS_HONOR_AI_TOKENS` | Boolean | `true` | Also honour rules naming AI crawler tokens (`ClaudeBot`, `GPTBot`, `CCBot`, ...). |
 | `GEMINI_DENIED_MIME_TYPES` | Comma-separated | empty | MIME types to reject; supports wildcards like `image/*`. |
 
 !!! note "TLS and certificates are not env-configurable"
@@ -184,8 +190,10 @@ GOPHER_ALLOW_LOCAL_HOSTS=false
 GEMINI_ALLOW_LOCAL_HOSTS=false
 GEMINI_TOFU_ENABLED=true
 GEMINI_TOFU_REJECT_EXPIRED=true
-GOPHER_REQUESTS_PER_MINUTE=60
-GEMINI_REQUESTS_PER_MINUTE=60
+GOPHER_REQUESTS_PER_MINUTE=30
+GEMINI_REQUESTS_PER_MINUTE=30
+GOPHER_RESPECT_ROBOTS_TXT=true
+GEMINI_RESPECT_ROBOTS_TXT=true
 GOPHER_MCP_LOG_LEVEL=INFO
 ```
 

--- a/src/gopher_mcp/config.py
+++ b/src/gopher_mcp/config.py
@@ -86,19 +86,43 @@ class GopherConfig(BaseSettings):
         le=1000000,
     )
     requests_per_minute: float = Field(
-        default=0.0,
+        default=60.0,  # one request per second, per host
         description="Per-host outbound request rate cap (politeness for small "
-        "Gopher servers); 0 = unlimited.",
+        "Gopher servers); 0 = unlimited. Defaults to one request per second "
+        "per host, which is imperceptible when browsing but stops a model "
+        "looping over the fetch tools from hammering one hobbyist server.",
         ge=0,
         le=6000,
     )
     max_concurrent_requests: int = Field(
-        default=0,
+        default=5,  # matches the batch tools' own concurrency
         description="Cap on simultaneous in-flight fetches (0 = unlimited); a "
         "coarse bound on concurrent sockets/memory, complementary to the "
-        "per-host rate limit. Off by default.",
+        "per-host rate limit. Defaults to the batch tools' own concurrency so "
+        "parallel tool calls cannot multiply past it.",
         ge=0,
         le=1000,
+    )
+    respect_robots_txt: bool = Field(
+        default=False,
+        description="Fetch and honour /robots.txt from the host root before "
+        "retrieving a resource, following the convention Veronica-2 documents "
+        "(User-agent 'gopher-mcp' and '*'). Off by default because it adds a "
+        "round-trip per host; see docs for the fail-open caveat.",
+    )
+    robots_cache_ttl_seconds: int = Field(
+        default=86400,  # 24 hours; RFC 9309 s2.4 permits up to this
+        description="How long a fetched robots.txt policy stays valid, in "
+        "seconds. RFC 9309 s2.4 permits up to 24 hours.",
+        ge=0,
+        le=604800,  # at most one week
+    )
+    robots_honor_ai_tokens: bool = Field(
+        default=True,
+        description="Also honour Disallow rules aimed at named AI crawler "
+        "tokens (ClaudeBot, GPTBot, CCBot, ...). These are not part of the "
+        "Gopher convention, but an operator who wrote one meant 'no LLM "
+        "tooling'.",
     )
 
     model_config = SettingsConfigDict(
@@ -208,20 +232,42 @@ class GeminiConfig(BaseSettings):
         le=10485760,
     )
     requests_per_minute: float = Field(
-        default=0.0,
+        default=60.0,  # one request per second, per host
         description="Per-host outbound request rate cap (politeness for small "
-        "Gemini servers); 0 = unlimited. A status-44 SLOW_DOWN is always "
-        "honoured regardless of this setting.",
+        "Gemini servers); 0 = unlimited. Defaults to one request per second "
+        "per host. A status-44 SLOW_DOWN is always honoured regardless of "
+        "this setting.",
         ge=0,
         le=6000,
     )
     max_concurrent_requests: int = Field(
-        default=0,
+        default=5,  # matches the batch tools' own concurrency
         description="Cap on simultaneous in-flight fetches (0 = unlimited); a "
         "coarse bound on concurrent sockets/memory, complementary to the "
-        "per-host rate limit. Off by default.",
+        "per-host rate limit. Defaults to the batch tools' own concurrency so "
+        "parallel tool calls cannot multiply past it.",
         ge=0,
         le=1000,
+    )
+    respect_robots_txt: bool = Field(
+        default=False,
+        description="Fetch and honour /robots.txt from the capsule root before "
+        "retrieving a resource, following the Gemini companion specification "
+        "(virtual agents 'webproxy' and 'indexer', plus '*'). Off by default "
+        "because it adds a round-trip per host.",
+    )
+    robots_cache_ttl_seconds: int = Field(
+        default=86400,  # 24 hours; RFC 9309 s2.4 permits up to this
+        description="How long a fetched robots.txt policy stays valid, in "
+        "seconds. RFC 9309 s2.4 permits up to 24 hours.",
+        ge=0,
+        le=604800,  # at most one week
+    )
+    robots_honor_ai_tokens: bool = Field(
+        default=True,
+        description="Also honour Disallow rules aimed at named AI crawler "
+        "tokens (ClaudeBot, GPTBot, CCBot, ...). Not part of the companion "
+        "spec, but capsules that name them mean 'no LLM tooling'.",
     )
     denied_mime_types: list[str] = Field(
         default_factory=list,

--- a/src/gopher_mcp/gemini_client.py
+++ b/src/gopher_mcp/gemini_client.py
@@ -19,6 +19,13 @@ from .models import (
     TOFUEntry,
 )
 from .ratelimit import RateLimiter
+from .robots import (
+    AI_AGENT_TOKENS,
+    GEMINI_TOKENS,
+    ROBOTS_MAX_BYTES,
+    RobotsGate,
+    RobotsUnavailable,
+)
 from .ssrf import SSRFError, normalize_host, validate_target
 from .tofu import (
     TOFUExpiredError,
@@ -42,6 +49,12 @@ DEFAULT_TIMEOUT_SECONDS = 30.0
 DEFAULT_CACHE_TTL_SECONDS = 300  # 5 minutes
 DEFAULT_MAX_CACHE_ENTRIES = 1000
 DEFAULT_MAX_RENDERED_CHARS = 50000  # LLM-facing text cap; 0 = unlimited
+# Politeness defaults. Gopher and Gemini are served largely by small
+# hobbyist hosts, and a model can call the fetch tools in a tight loop, so
+# both are on out of the box rather than opt-in.
+DEFAULT_REQUESTS_PER_MINUTE = 60.0  # one request per second, per host
+DEFAULT_MAX_CONCURRENT_REQUESTS = 5  # matches the batch tools' concurrency
+DEFAULT_ROBOTS_CACHE_TTL_SECONDS = 86400  # RFC 9309 s2.4 permits 24h
 
 
 def _safe_display_url(parsed_url: GeminiURL) -> str:
@@ -79,9 +92,12 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         client_certs_enabled: bool = True,
         client_certs_storage_path: str | None = None,
         max_rendered_chars: int = DEFAULT_MAX_RENDERED_CHARS,
-        requests_per_minute: float = 0.0,
-        max_concurrent_requests: int = 0,
+        requests_per_minute: float = DEFAULT_REQUESTS_PER_MINUTE,
+        max_concurrent_requests: int = DEFAULT_MAX_CONCURRENT_REQUESTS,
         denied_mime_types: list[str] | None = None,
+        respect_robots_txt: bool = False,
+        robots_cache_ttl_seconds: int = DEFAULT_ROBOTS_CACHE_TTL_SECONDS,
+        robots_honor_ai_tokens: bool = True,
     ) -> None:
         """Initialize the Gemini client.
 
@@ -99,6 +115,11 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
                 validity window instead of accepting it with a warning
             client_certs_enabled: Whether to enable client certificate management
             client_certs_storage_path: Path to client certificate storage directory
+            respect_robots_txt: Consult /robots.txt at the capsule root before
+                fetching, per the Gemini companion specification
+            robots_cache_ttl_seconds: Lifetime of a cached robots policy
+            robots_honor_ai_tokens: Also honour rules naming AI crawler tokens
+                (ClaudeBot, GPTBot, ...)
         """
         self.max_response_size = max_response_size
         self.timeout_seconds = timeout_seconds
@@ -108,7 +129,7 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         self.max_rendered_chars = max_rendered_chars
         self._rate_limiter = RateLimiter(requests_per_minute)
         self.max_concurrent_requests = max_concurrent_requests
-        # Opt-in coarse cap on simultaneous fetches (None = unlimited).
+        # Coarse cap on simultaneous fetches; 0 disables it (None = unlimited).
         self._fetch_semaphore = (
             asyncio.Semaphore(max_concurrent_requests)
             if max_concurrent_requests > 0
@@ -159,6 +180,25 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
         # is inherited from the mixin annotation; only the entry class differs.
         self._cache = OrderedDict()
         self._cache_entry_cls = GeminiCacheEntry
+
+        # Robot exclusion (opt-in), following the Gemini companion spec rather
+        # than RFC 9309. Unlike Gopher this fails *closed* on a temporary
+        # failure (RFC 9309 s2.3.1.4), which Gemini can express because it has
+        # status codes -- see :meth:`_fetch_robots` for the 4x/5x mapping.
+        self.respect_robots_txt = respect_robots_txt
+        self._robots_gate = (
+            RobotsGate(
+                # Resolved at call time rather than bound here, so the
+                # gate follows the method (and stays patchable in tests).
+                fetcher=lambda host, port: self._fetch_robots(host, port),
+                tokens=GEMINI_TOKENS,
+                extra_tokens=(AI_AGENT_TOKENS if robots_honor_ai_tokens else ()),
+                ttl_seconds=robots_cache_ttl_seconds,
+                fail_closed=True,
+            )
+            if respect_robots_txt
+            else None
+        )
 
     def _tls_client_for_cert(self, cert_path: str, key_path: str) -> GeminiTLSClient:
         """Return a TLS client bound to a client certificate, cached per pair.
@@ -219,6 +259,15 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
 
             # Validate security constraints
             self._validate_security(parsed_url)
+
+            # Robot exclusion, before the cache lookup below: a Disallow must
+            # also withhold content cached from an earlier, permitted run.
+            if self._robots_gate is not None:
+                decision = await self._robots_gate.allows(
+                    parsed_url.host, parsed_url.port, [parsed_url.path]
+                )
+                if not decision.allowed:
+                    return self._robots_denied_result(parsed_url, decision.reason)
 
             # Canonical cache key (case-insensitive host) so requests differing
             # only in host case share one entry instead of duplicating.
@@ -384,18 +433,133 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
             seconds = 60.0
         self._rate_limiter.penalize(host, seconds)
 
+    def _robots_denied_result(
+        self, parsed_url: GeminiURL, reason: str
+    ) -> GeminiErrorResult:
+        """Build the result returned when the robots gate blocks a resource."""
+        logger.info(
+            "Blocked by robots.txt",
+            host=parsed_url.host,
+            path=parsed_url.path,
+            reason=reason,
+        )
+        if reason == "unavailable":
+            message = (
+                f"Could not retrieve robots.txt from {parsed_url.host}, so access "
+                f"is denied (RFC 9309 section 2.3.1.4 treats a temporary failure "
+                f"as a complete disallow). Set GEMINI_RESPECT_ROBOTS_TXT=false to "
+                f"disable robots checking."
+            )
+        else:
+            message = (
+                f"{parsed_url.host} disallows this resource in its robots.txt. "
+                f"Set GEMINI_RESPECT_ROBOTS_TXT=false to disable robots checking."
+            )
+        return GeminiErrorResult(
+            error={"code": "BLOCKED_BY_ROBOTS", "message": message},
+            requestInfo={
+                "url": _safe_display_url(parsed_url),
+                "host": parsed_url.host,
+                "port": parsed_url.port,
+                "path": parsed_url.path,
+                "timestamp": time.time(),
+            },
+        )
+
+    async def _fetch_robots(self, host: str, port: int) -> str | None:
+        """Fetch ``/robots.txt`` for the robots gate.
+
+        Calls :meth:`_fetch_content` directly rather than :meth:`fetch`: the
+        former would recurse into the gate, and :meth:`_bounded_fetch` holds
+        ``_fetch_semaphore``, so a lookup issued from inside it would deadlock
+        whenever ``max_concurrent_requests`` is 1.
+
+        Status mapping is deliberately *not* the HTTP one. Gemini inverts the
+        numbering: 5x is the permanent class, and ``51 NOT FOUND`` is the normal
+        answer from a capsule that simply has no robots.txt, so 5x means "no
+        policy, allow everything" (RFC 9309 s2.3.1.3). 4x is the temporary class
+        and maps to s2.3.1.4's complete disallow. A capsule that demands a client
+        certificate (6x) cannot serve us a policy at all, so it is allowed
+        through -- the resource itself is gated by the certificate anyway.
+        """
+        robots_url = GeminiURL(host=host, port=port, path="/robots.txt", query=None)
+        # This bypasses _bounded_fetch (see above), which is where the per-host
+        # spacing is now applied, so throttle here instead.
+        await self._rate_limiter.acquire(host)
+        try:
+            result = await self._fetch_content(
+                robots_url,
+                # Never read more than the operator allows for a normal body.
+                max_bytes=min(ROBOTS_MAX_BYTES, self.max_response_size),
+                apply_content_policy=False,
+            )
+        except (
+            GeminiProtocolError,
+            TLSConnectionError,
+            SSRFError,
+            OSError,
+            TimeoutError,
+        ) as e:
+            raise RobotsUnavailable(f"could not reach {host}:{port}") from e
+
+        # A 44 SLOW_DOWN here is still the server asking us to back off, and the
+        # backoff must be recorded even though this response is discarded.
+        self._maybe_honor_slow_down(host, result)
+
+        kind = getattr(result, "kind", None)
+        if kind in ("success", "gemtext"):
+            # text/gemini is the Gemini default MIME -- it is what an absent,
+            # empty or unparseable meta falls back to -- so a policy served that
+            # way arrives as GeminiGemtextResult, which carries its text in
+            # `raw_content` rather than `content`. Reading only `content` would
+            # silently discard the policy and cache allow-all for the full TTL.
+            body = getattr(result, "content", None)
+            if body is None:
+                body = getattr(result, "raw_content", None)
+            return body if isinstance(body, str) else None
+        if kind == "error":
+            status = getattr(result, "error", {}).get("status")
+            if isinstance(status, int) and 40 <= status <= 49:
+                raise RobotsUnavailable(f"status {status} fetching robots.txt")
+            # 5x (including 51 NOT FOUND) and anything unclassifiable: no policy.
+            return None
+        # Redirect, input prompt, certificate request or a binary body: none of
+        # these is a policy we can apply, so nothing is disallowed.
+        return None
+
     async def _bounded_fetch(self, parsed_url: GeminiURL) -> GeminiFetchResponse:
-        """Run :meth:`_fetch_content`, bounded by the concurrency cap if set."""
+        """Run :meth:`_fetch_content`, bounded by the concurrency cap if set.
+
+        The per-host spacing is waited out BEFORE a concurrency slot is
+        taken. Sleeping while holding the semaphore would let one
+        throttled host occupy every slot, starving unrelated hosts that
+        are not rate limited at all -- harmless when both settings were
+        off by default, but not now that they ship enabled.
+        """
+        await self._rate_limiter.acquire(parsed_url.host)
         if self._fetch_semaphore is None:
             return await self._fetch_content(parsed_url)
         async with self._fetch_semaphore:
             return await self._fetch_content(parsed_url)
 
-    async def _fetch_content(self, parsed_url: GeminiURL) -> GeminiFetchResponse:
+    async def _fetch_content(
+        self,
+        parsed_url: GeminiURL,
+        *,
+        max_bytes: int | None = None,
+        apply_content_policy: bool = True,
+    ) -> GeminiFetchResponse:
         """Fetch content from parsed Gemini URL using TLS.
 
         Args:
             parsed_url: Parsed Gemini URL
+            max_bytes: Optional response-size cap for this request only,
+                used by the robots.txt lookup so a capsule cannot make the
+                gate download a full-sized body.
+            apply_content_policy: When False, skip the LLM-facing render cap
+                and the MIME deny list. Both exist to shape what reaches the
+                model; applying them to a robots.txt would silently truncate
+                a policy mid-file or discard it entirely.
 
         Returns:
             Appropriate response based on status code
@@ -424,10 +588,6 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
             connect_ip = next(
                 (a for a in connect_addresses if ":" not in a), connect_addresses[0]
             )
-
-            # Politeness: space out requests to the same host (and honour any
-            # outstanding status-44 backoff for it).
-            await self._rate_limiter.acquire(parsed_url.host)
 
             # Check for client certificate
             client_cert_path = None
@@ -529,7 +689,9 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
             # dripping bytes is actually cut off at the deadline (no thread is
             # left parked on a blocking recv).
             raw_response = await asyncio.wait_for(
-                self.tls_client.receive_data(connection, self.max_response_size),
+                self.tls_client.receive_data(
+                    connection, max_bytes or self.max_response_size
+                ),
                 timeout=self.timeout_seconds,
             )
 
@@ -541,8 +703,12 @@ class GeminiClient(TTLCacheMixin[GeminiFetchResponse]):
                 parsed_response,
                 request_url,
                 time.time(),
-                max_rendered_chars=self.max_rendered_chars,
-                denied_mime_types=self.denied_mime_types,
+                max_rendered_chars=(
+                    self.max_rendered_chars if apply_content_policy else 0
+                ),
+                denied_mime_types=(
+                    self.denied_mime_types if apply_content_policy else None
+                ),
             )
 
             # Add connection info to request info

--- a/src/gopher_mcp/gopher_client.py
+++ b/src/gopher_mcp/gopher_client.py
@@ -19,6 +19,14 @@ from .models import (
     TextResult,
 )
 from .ratelimit import RateLimiter
+from .robots import (
+    AI_AGENT_TOKENS,
+    GOPHER_TOKENS,
+    ROBOTS_MAX_BYTES,
+    RobotsGate,
+    RobotsUnavailable,
+    gopher_candidate_paths,
+)
 from .ssrf import SSRFError, normalize_host, validate_target
 from .utils import (
     detect_binary_mime_type,
@@ -40,6 +48,12 @@ DEFAULT_MAX_SELECTOR_LENGTH = 1024
 DEFAULT_MAX_SEARCH_LENGTH = 256
 DEFAULT_MAX_RENDERED_CHARS = 50000  # LLM-facing text cap; 0 = unlimited
 DEFAULT_MAX_MENU_ITEMS = 1000  # LLM-facing menu item cap; 0 = unlimited
+# Politeness defaults. Gopher and Gemini are served largely by small
+# hobbyist hosts, and a model can call the fetch tools in a tight loop, so
+# both are on out of the box rather than opt-in.
+DEFAULT_REQUESTS_PER_MINUTE = 60.0  # one request per second, per host
+DEFAULT_MAX_CONCURRENT_REQUESTS = 5  # matches the batch tools' concurrency
+DEFAULT_ROBOTS_CACHE_TTL_SECONDS = 86400  # RFC 9309 s2.4 permits 24h
 
 
 def _strip_gopher_text_terminator(text: str) -> str:
@@ -93,8 +107,11 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
         max_search_length: int = DEFAULT_MAX_SEARCH_LENGTH,
         max_rendered_chars: int = DEFAULT_MAX_RENDERED_CHARS,
         max_menu_items: int = DEFAULT_MAX_MENU_ITEMS,
-        requests_per_minute: float = 0.0,
-        max_concurrent_requests: int = 0,
+        requests_per_minute: float = DEFAULT_REQUESTS_PER_MINUTE,
+        max_concurrent_requests: int = DEFAULT_MAX_CONCURRENT_REQUESTS,
+        respect_robots_txt: bool = False,
+        robots_cache_ttl_seconds: int = DEFAULT_ROBOTS_CACHE_TTL_SECONDS,
+        robots_honor_ai_tokens: bool = True,
     ) -> None:
         """Initialize the Gopher client.
 
@@ -109,6 +126,11 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             max_search_length: Maximum search query length
             max_concurrent_requests: Cap on simultaneous in-flight fetches
                 (0 = unlimited); a coarse bound on concurrent sockets/memory.
+            respect_robots_txt: Consult /robots.txt at the host root before
+                fetching, per the convention Veronica-2 documents.
+            robots_cache_ttl_seconds: Lifetime of a cached robots policy.
+            robots_honor_ai_tokens: Also honour rules naming AI crawler
+                tokens (ClaudeBot, GPTBot, ...).
 
         """
         self.max_response_size = max_response_size
@@ -122,7 +144,7 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
         self.max_menu_items = max_menu_items
         self._rate_limiter = RateLimiter(requests_per_minute)
         self.max_concurrent_requests = max_concurrent_requests
-        # Opt-in coarse cap on simultaneous fetches (None = unlimited).
+        # Coarse cap on simultaneous fetches; 0 disables it (None = unlimited).
         self._fetch_semaphore = (
             asyncio.Semaphore(max_concurrent_requests)
             if max_concurrent_requests > 0
@@ -141,6 +163,27 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
         # is inherited from the mixin annotation; only the entry class differs.
         self._cache = OrderedDict()
         self._cache_entry_cls = CacheEntry
+
+        # Robot exclusion (opt-in). Gopher fails *open*: the protocol has no
+        # status codes, so a missing selector, an error document and an empty
+        # file are indistinguishable on the wire, and RFC 9309 s2.3.1.4's
+        # "treat unreachable as complete disallow" would deny most of
+        # Gopherspace. The lenient parser makes that safe -- an error page
+        # yields no User-agent group and so imposes no rules.
+        self.respect_robots_txt = respect_robots_txt
+        self._robots_gate = (
+            RobotsGate(
+                # Resolved at call time rather than bound here, so the
+                # gate follows the method (and stays patchable in tests).
+                fetcher=lambda host, port: self._fetch_robots(host, port),
+                tokens=GOPHER_TOKENS,
+                extra_tokens=(AI_AGENT_TOKENS if robots_honor_ai_tokens else ()),
+                ttl_seconds=robots_cache_ttl_seconds,
+                fail_closed=False,
+            )
+            if respect_robots_txt
+            else None
+        )
 
     def _validate_security(self, parsed_url: GopherURL) -> None:
         """Validate security constraints for a Gopher request.
@@ -203,6 +246,19 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
 
             # Validate security constraints
             self._validate_security(parsed_url)
+
+            # Robot exclusion, before the cache lookup below: a Disallow must
+            # also withhold content cached from an earlier, permitted run.
+            if self._robots_gate is not None:
+                decision = await self._robots_gate.allows(
+                    parsed_url.host,
+                    parsed_url.port,
+                    gopher_candidate_paths(parsed_url.gopher_type, parsed_url.selector),
+                )
+                if not decision.allowed:
+                    return self._robots_denied_result(
+                        url, parsed_url.host, decision.reason
+                    )
 
             # Canonical cache key (case-insensitive host) so requests differing
             # only in host case share one entry instead of duplicating.
@@ -291,8 +347,80 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             requestInfo={"url": url, "timestamp": time.time()},
         )
 
+    def _robots_denied_result(self, url: str, host: str, reason: str) -> ErrorResult:
+        """Build the result returned when the robots gate blocks a resource."""
+        logger.info("Blocked by robots.txt", url=url, host=host, reason=reason)
+        return ErrorResult(
+            error={
+                "code": "BLOCKED_BY_ROBOTS",
+                "message": (
+                    f"{host} disallows this resource in its robots.txt. "
+                    f"Set GOPHER_RESPECT_ROBOTS_TXT=false to disable robots "
+                    f"checking."
+                ),
+            },
+            requestInfo={"url": url, "timestamp": time.time()},
+        )
+
+    async def _fetch_robots(self, host: str, port: int) -> str | None:
+        """Fetch ``/robots.txt`` for the robots gate.
+
+        Deliberately bypasses :meth:`fetch` and :meth:`_bounded_fetch`: going
+        through the former would recurse into the gate, and the latter holds
+        ``_fetch_semaphore``, so a robots lookup issued from inside it would
+        deadlock whenever ``max_concurrent_requests`` is 1. The SSRF guard and
+        the per-host rate limiter still apply.
+
+        A failure raises :class:`RobotsUnavailable` rather than returning
+        ``None``. The two are not interchangeable: ``None`` means "the server
+        answered and has no policy", which the gate caches for the full TTL,
+        so reporting a timeout that way would disable robots checking for the
+        host for 24 hours. The gate is configured ``fail_closed=False`` here, so
+        an unavailable policy still allows the request through (Gopher cannot
+        distinguish a missing selector from an unreachable server, and the real
+        fetch would fail the same way) -- it just is not remembered.
+        """
+        try:
+            connect_addresses = await asyncio.wait_for(
+                validate_target(
+                    host,
+                    port,
+                    allow_local=self.allow_local_hosts,
+                    allowed_ports=self.allowed_ports,
+                ),
+                timeout=self.timeout_seconds,
+            )
+            await self._rate_limiter.acquire(host)
+            raw = await fetch_gopher(
+                host,
+                port,
+                "/robots.txt",
+                None,
+                max_bytes=ROBOTS_MAX_BYTES,
+                timeout=self.timeout_seconds,
+                connect_addresses=connect_addresses,
+            )
+        except (
+            SSRFError,
+            GopherProtocolError,
+            OSError,
+            TimeoutError,
+            ValueError,
+        ) as e:
+            raise RobotsUnavailable(f"could not reach {host}:{port}") from e
+        text, _charset = decode_gopher_text(raw)
+        return text
+
     async def _bounded_fetch(self, parsed_url: GopherURL) -> GopherFetchResponse:
-        """Run :meth:`_fetch_content`, bounded by the concurrency cap if set."""
+        """Run :meth:`_fetch_content`, bounded by the concurrency cap if set.
+
+        The per-host spacing is waited out BEFORE a concurrency slot is
+        taken. Sleeping while holding the semaphore would let one
+        throttled host occupy every slot, starving unrelated hosts that
+        are not rate limited at all -- harmless when both settings were
+        off by default, but not now that they ship enabled.
+        """
+        await self._rate_limiter.acquire(parsed_url.host)
         if self._fetch_semaphore is None:
             return await self._fetch_content(parsed_url)
         async with self._fetch_semaphore:
@@ -352,9 +480,6 @@ class GopherClient(TTLCacheMixin[GopherFetchResponse]):
             raise GopherProtocolError(
                 f"Timed out resolving host '{parsed_url.host}'"
             ) from e
-
-        # Politeness: space out requests to the same (often small) host.
-        await self._rate_limiter.acquire(parsed_url.host)
 
         # RFC 1436 only defines the <TAB>query field for type-7 (Index-Search)
         # servers; never forward a stray search to a plain selector.

--- a/src/gopher_mcp/ratelimit.py
+++ b/src/gopher_mcp/ratelimit.py
@@ -6,8 +6,9 @@ so both clients route each outbound request through a :class:`RateLimiter` that
 enforces a minimum spacing between requests *to the same host* and honours a
 server's request to slow down (Gemini status 44).
 
-The limiter is disabled by default (``requests_per_minute=0``); operators opt in
-via ``GOPHER_REQUESTS_PER_MINUTE`` / ``GEMINI_REQUESTS_PER_MINUTE``.
+The limiter is ENABLED by default at 60 requests per minute per host (one per
+second). Set ``GOPHER_REQUESTS_PER_MINUTE`` / ``GEMINI_REQUESTS_PER_MINUTE`` to
+0 to disable it, or to another value to retune it.
 """
 
 import asyncio

--- a/src/gopher_mcp/robots.py
+++ b/src/gopher_mcp/robots.py
@@ -1,0 +1,448 @@
+"""Robot exclusion (``robots.txt``) support for the Gopher and Gemini clients.
+
+Neither Gopher nor Gemini sends a User-Agent header, so a server cannot
+recognise this client on the wire. Both ecosystems solved that the same way: a
+``/robots.txt`` at the host root naming *virtual* user agents that describe what
+a bot does rather than what software it is.
+
+Which convention applies depends on the protocol:
+
+* **Gemini** follows the official companion specification at
+  ``gemini://geminiprotocol.net/docs/companion/robots.gmi``, which defines the
+  tokens ``archiver``, ``indexer``, ``researcher`` and ``webproxy``, and uses
+  the *original 1994* robots.txt grammar: only ``#``, ``User-agent:`` and
+  ``Disallow:`` are recognised, and "All other lines are ignored". There is no
+  ``Allow:``. An RFC 9309 parser would therefore act on ``Allow:`` lines that
+  capsule authors expect to be dropped and end up *more permissive* than
+  intended, which is why this module carries its own parser rather than using
+  ``urllib.robotparser``, ``protego`` or ``reppy``.
+* **Gopher** follows the convention Veronica-2 documents at
+  ``gopher://gopher.floodgap.com/0/v2/help/indexer`` ("you can use a regular old
+  robots.txt file ... Veronica-2 obeys User-agent of 'veronica' and '*'"), which
+  uses the same 1994 grammar.
+
+RFC 9309 is not the normative reference for either protocol, but it is
+scheme-generic (§1 scopes it to any RFC 3986 URI, and §2.3 uses an ``ftp://``
+example) and its file-location rule is followed here: ``robots.txt`` lives at
+the top-level path of the service and nowhere else. Neither that RFC nor either
+protocol convention defines a per-directory or per-user ``robots.txt``; on
+shared hosts the established pattern is a single root file using path prefixes.
+
+Two deliberate departures from a strict 1994 reading, both chosen because they
+can only ever make this client *less* permissive:
+
+* ``*`` and ``$`` in a ``Disallow`` value are honoured as wildcards. The 1994
+  grammar treats them literally, but authors who write them plainly intend the
+  broader match.
+* When several of our tokens match, the union of their rules applies rather than
+  the first match. This follows the companion spec's own tie-breaker: when more
+  than one category applies, "obey the most restrictive set of directives".
+"""
+
+import asyncio
+import posixpath
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from urllib.parse import unquote
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# RFC 9309 §2.5 asks parsers to handle at least 500 KiB. A real robots.txt is a
+# fraction of that; the cap matters because a Gopher server has no way to say
+# "no such selector" and may answer with an arbitrary menu or error document.
+ROBOTS_MAX_BYTES = 512_000
+
+# Advertised token for this project. The Gemini companion spec explicitly lets a
+# bot honour directives aimed at "their own individual User-agent which they
+# prominently advertise", so operators can name us specifically.
+PROJECT_TOKEN = "gopher-mcp"  # nosec B105 - a robots.txt agent name, not a secret
+
+# Gopher: Veronica-2's documented convention. `veronica` is deliberately NOT
+# claimed -- that token belongs to Floodgap's indexer, not to us.
+GOPHER_TOKENS: tuple[str, ...] = (PROJECT_TOKEN, "*")
+
+# Gemini: the companion spec's virtual agents that actually describe this tool.
+# `webproxy` covers the on-demand, human-triggered fetch; `indexer` is included
+# because the batch tools fetch many URLs at once, which is crawl-shaped.
+# `archiver` and `researcher` are NOT claimed: nothing here retains content, and
+# `researcher` requires operating "without rehosting, linking to, or allowing
+# search of any fetched content", which is the opposite of showing page text to
+# a user.
+GEMINI_TOKENS: tuple[str, ...] = (PROJECT_TOKEN, "webproxy", "indexer", "*")
+
+# Product tokens used by AI crawlers on the HTTP web. These are not part of
+# either protocol's convention and are largely transplanted boilerplate where
+# they appear in Gopherspace/Geminispace -- but an operator who wrote one meant
+# "no LLM tooling", and honouring that costs nothing.
+AI_AGENT_TOKENS: tuple[str, ...] = (
+    "anthropic-ai",
+    "ccbot",
+    "chatgpt-user",
+    "claude-code",
+    "claude-searchbot",
+    "claude-user",
+    "claude-web",
+    "claudebot",
+    "cohere-ai",
+    "gptbot",
+    "oai-searchbot",
+    "perplexity-user",
+    "perplexitybot",
+)
+
+
+class RobotsUnavailable(Exception):
+    """The policy for a host could not be determined.
+
+    Raised by a fetcher for a *temporary* failure, which RFC 9309 §2.3.1.4 says
+    must be treated as a complete disallow. A permanently absent file is not
+    this: a fetcher signals "no policy, allow everything" by returning ``None``.
+    """
+
+
+@dataclass
+class RobotsPolicy:
+    """Parsed ``robots.txt`` groups: lowercased agent token -> disallow rules.
+
+    An empty ``groups`` mapping means no policy was found and everything is
+    allowed, which is also what unparseable content collapses to.
+    """
+
+    groups: dict[str, list[str]] = field(default_factory=dict)
+
+    def is_allowed(
+        self,
+        paths: list[str],
+        tokens: tuple[str, ...],
+        extra_tokens: tuple[str, ...] = (),
+    ) -> bool:
+        """Return whether any of ``paths`` may be fetched under ``tokens``.
+
+        ``paths`` is a list of candidate spellings of the same resource (Gopher
+        needs several; see :func:`gopher_candidate_paths`). A rule matching any
+        candidate denies the fetch.
+
+        ``extra_tokens`` (the named AI crawler agents) are *additive only*: their
+        rules are unioned into whatever the protocol tokens select, but matching
+        one never suppresses the catch-all group. Treating them like ordinary
+        specific tokens would invert their purpose -- a capsule with a blanket
+        ``User-agent: *`` / ``Disallow: /`` plus a narrower ``User-agent:
+        ClaudeBot`` section would end up granting us *more* access than a client
+        that ignored the AI tokens entirely.
+        """
+        if not self.groups:
+            return True
+
+        # Specific tokens win over the catch-all, and all matching specific
+        # groups apply together (most-restrictive tie-breaker). A specific group
+        # that is *present but empty* still wins: writing "User-agent: webproxy"
+        # followed by a bare "Disallow:" is how an operator grants us access a
+        # blanket "User-agent: *" rule would otherwise deny.
+        matched_specific = False
+        rules: list[str] = []
+        for agent in tokens:
+            if agent != "*" and agent in self.groups:
+                matched_specific = True
+                rules.extend(self.groups[agent])
+
+        if not matched_specific and "*" in tokens:
+            rules = list(self.groups.get("*", []))
+
+        for agent in extra_tokens:
+            if agent in self.groups:
+                rules.extend(self.groups[agent])
+
+        if not rules:
+            return True
+
+        candidates = expand_path_candidates(paths)
+        # Normalise the rules as well: an operator may write "/%7Eprivate/"
+        # while the request carries "/~private/". Expanding only one side would
+        # miss the cross case.
+        expanded_rules = []
+        for rule in rules:
+            if rule not in expanded_rules:
+                expanded_rules.append(rule)
+            decoded = unquote(rule)
+            if decoded not in expanded_rules:
+                expanded_rules.append(decoded)
+        return not any(
+            _matches(rule, path) for rule in expanded_rules for path in candidates
+        )
+
+
+def _matches(rule: str, path: str) -> bool:
+    """Return whether ``rule`` (a Disallow value) covers ``path``.
+
+    Plain prefix match, extended with ``*`` (any sequence) and ``$`` (end
+    anchor). An empty rule never matches: ``Disallow:`` with no value is the
+    1994 way to say "nothing is disallowed".
+
+    Matching is a linear greedy scan rather than a translated regular
+    expression. ``rule`` comes verbatim from a remote server, and a pattern such
+    as ``/********zzz`` compiles to adjacent unbounded ``.*`` groups whose
+    backtracking cost is exponential in the number of stars -- eleven seconds at
+    eight stars, and this runs synchronously on the event loop. A greedy scan is
+    O(len(rule) x len(path)) for this pattern class and gives the same answer:
+    each literal segment only ever needs its leftmost placement, because the
+    wildcard before it can absorb anything skipped.
+    """
+    if not rule:
+        return False
+
+    anchored = rule.endswith("$")
+    pattern = rule[:-1] if anchored else rule
+
+    if "*" not in pattern:
+        return path == pattern if anchored else path.startswith(pattern)
+
+    segments = pattern.split("*")
+
+    # The segment before the first star must sit at the start of the path.
+    if not path.startswith(segments[0]):
+        return False
+    pos = len(segments[0])
+
+    # Interior segments may appear anywhere after the previous match.
+    for segment in segments[1:-1]:
+        if not segment:
+            continue
+        found = path.find(segment, pos)
+        if found == -1:
+            return False
+        pos = found + len(segment)
+
+    tail = segments[-1]
+    if not tail:
+        # Pattern ends in a star, which absorbs whatever is left.
+        return True
+    if anchored:
+        return path.endswith(tail) and len(path) - len(tail) >= pos
+    return path.find(tail, pos) != -1
+
+
+def expand_path_candidates(paths: list[str]) -> list[str]:
+    """Return each path plus the other spellings a rule might be written in.
+
+    A rule and a request can disagree on percent-encoding (``/%7Euser`` versus
+    ``/~user``) or carry dot segments (``/pub/../private``), and matching only
+    the literal request path would let either slip past a Disallow. Every
+    spelling is tested and any match denies, so normalisation can only make this
+    stricter.
+    """
+    candidates: list[str] = []
+    for path in paths:
+        for variant in (path, unquote(path)):
+            if variant not in candidates:
+                candidates.append(variant)
+            if "./" in variant or variant.endswith("/.."):
+                resolved = posixpath.normpath(variant)
+                if variant.endswith("/") and not resolved.endswith("/"):
+                    resolved += "/"
+                if resolved not in candidates:
+                    candidates.append(resolved)
+    return candidates
+
+
+def parse_robots(text: str) -> RobotsPolicy:
+    """Parse ``robots.txt`` content using the original 1994 grammar.
+
+    Only ``User-agent:`` and ``Disallow:`` are recognised; every other field --
+    including ``Allow:``, ``Crawl-delay:`` and ``Sitemap:`` -- is ignored, per
+    the Gemini companion spec and the pre-RFC convention Gopher indexers follow.
+
+    Content that yields no ``User-agent:`` group at all produces an empty policy
+    (allow everything). That is what makes it safe to feed this whatever a
+    Gopher server returned for a selector it does not have: an error page or a
+    menu simply parses to nothing.
+    """
+    groups: dict[str, list[str]] = {}
+    # Tokens whose group is still open, i.e. consecutive User-agent lines that
+    # share the Disallow rules that follow them.
+    current: list[str] = []
+    # A Disallow line closes the run of User-agent lines above it; the next
+    # User-agent then starts a fresh group.
+    accepting_agents = True
+
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+
+        field_name, sep, value = line.partition(":")
+        if not sep:
+            continue
+        field_name = field_name.strip().lower()
+        value = value.strip()
+
+        if field_name == "user-agent":
+            if not accepting_agents:
+                current = []
+                accepting_agents = True
+            if value:
+                token = value.lower()
+                current.append(token)
+                groups.setdefault(token, [])
+        else:
+            # ANY non-User-agent field closes the run of agent lines above it,
+            # not just Disallow. Otherwise "User-agent: a / Allow: /x /
+            # User-agent: b / Disallow: /y" would treat a and b as one group and
+            # apply b's rules to a -- an ignored field must not silently merge
+            # two unrelated records.
+            accepting_agents = False
+            if field_name != "disallow" or not current or not value:
+                continue
+            for token in current:
+                groups[token].append(value)
+
+    return RobotsPolicy(groups)
+
+
+def gopher_candidate_paths(gopher_type: str, selector: str) -> list[str]:
+    """Return the path spellings a Gopher rule might be written against.
+
+    A Gopher URI carries the item type as the first path segment character, so
+    ``gopher://host/0/users/foo`` has the URI path ``/0/users/foo`` while the
+    on-wire selector is ``/users/foo``. Operators write rules both ways --
+    quux.org's own file lists ``Disallow: /Archives/mirrors/`` *and*
+    ``Disallow: 1/Archives/mirrors/`` to cover the ambiguity -- so a rule that
+    matches any spelling is honoured.
+    """
+    sel = selector if selector.startswith("/") else f"/{selector}"
+    return [sel, f"/{gopher_type}{sel}", f"{gopher_type}{sel}"]
+
+
+@dataclass
+class RobotsDecision:
+    """The outcome of a gate check, and the reason behind it."""
+
+    allowed: bool
+    # "allowed" | "disallowed" | "unavailable"
+    reason: str = "allowed"
+
+
+@dataclass
+class _CachedPolicy:
+    policy: RobotsPolicy
+    expires_at: float
+
+
+class RobotsGate:
+    """Per-host ``robots.txt`` lookup with caching, for one protocol client.
+
+    The fetcher is injected so this class stays protocol-agnostic and directly
+    testable. It must fetch ``/robots.txt`` from the host root *without* going
+    back through the client's own gated fetch path, and must return ``None`` for
+    "no policy here" or raise :class:`RobotsUnavailable` for a temporary failure.
+    """
+
+    def __init__(
+        self,
+        *,
+        fetcher: Callable[[str, int], Awaitable[str | None]],
+        tokens: tuple[str, ...],
+        extra_tokens: tuple[str, ...] = (),
+        ttl_seconds: int,
+        fail_closed: bool,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Initialize the gate.
+
+        Args:
+            fetcher: Coroutine ``(host, port) -> robots.txt text or None``.
+            tokens: Protocol agent tokens to match, most specific first.
+            extra_tokens: Additive-only tokens (the named AI crawler
+                agents). Their rules are unioned in but never suppress the
+                catch-all group; see :meth:`RobotsPolicy.is_allowed`.
+            ttl_seconds: How long a fetched policy stays valid. RFC 9309 §2.4
+                permits up to 24h; Floodgap suggests "several hours up to a day".
+            fail_closed: What to do when the fetcher raises
+                :class:`RobotsUnavailable`. True denies (RFC 9309 §2.3.1.4);
+                False allows, which is the only workable choice for Gopher.
+            clock: Monotonic clock source (injectable for tests).
+        """
+        self._fetcher = fetcher
+        self._tokens = tokens
+        self._extra_tokens = extra_tokens
+        self._ttl_seconds = ttl_seconds
+        self._fail_closed = fail_closed
+        self._clock = clock
+        self._cache: dict[str, _CachedPolicy] = {}
+        # One lock per host so a batch of concurrent fetches to the same server
+        # triggers a single robots.txt request rather than one per URL.
+        self._locks: dict[str, asyncio.Lock] = {}
+        # An open-world fetcher sees an unbounded number of distinct hosts, so
+        # neither map may grow without limit (the rate limiter has the same
+        # constraint and solves it the same way). Past this many entries, sweep
+        # out expired policies and unheld locks -- both are reconstructible, so
+        # dropping them is behaviour-preserving.
+        self._sweep_threshold = 1024
+
+    async def allows(self, host: str, port: int, paths: list[str]) -> RobotsDecision:
+        """Return whether ``paths`` on ``host:port`` may be fetched."""
+        policy = await self._policy_for(host, port)
+        if policy is None:
+            # Undeterminable; the fail-open/closed choice is the caller's.
+            return RobotsDecision(allowed=not self._fail_closed, reason="unavailable")
+        if policy.is_allowed(paths, self._tokens, self._extra_tokens):
+            return RobotsDecision(allowed=True)
+        return RobotsDecision(allowed=False, reason="disallowed")
+
+    async def _policy_for(self, host: str, port: int) -> RobotsPolicy | None:
+        # Strip the FQDN trailing dot so "example.com." and "example.com"
+        # share one policy rather than each getting their own.
+        key = f"{host.lower().rstrip('.')}:{port}"
+
+        cached = self._cache.get(key)
+        if cached is not None and cached.expires_at > self._clock():
+            return cached.policy
+
+        if (
+            len(self._cache) > self._sweep_threshold
+            or len(self._locks) > self._sweep_threshold
+        ):
+            self._sweep()
+
+        lock = self._locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            # Re-check: another waiter may have populated the entry while we
+            # queued on the lock.
+            cached = self._cache.get(key)
+            if cached is not None and cached.expires_at > self._clock():
+                return cached.policy
+
+            try:
+                text = await self._fetcher(host, port)
+            except RobotsUnavailable as e:
+                logger.debug(
+                    "robots.txt unavailable", host=host, port=port, reason=str(e)
+                )
+                # Deliberately not cached: a temporary failure should be retried,
+                # not pinned for the whole TTL. Fall back to the stale policy if
+                # we have one rather than throwing away a known-good answer.
+                stale = self._cache.get(key)
+                return stale.policy if stale is not None else None
+
+            policy = parse_robots(text) if text is not None else RobotsPolicy()
+            self._cache[key] = _CachedPolicy(
+                policy=policy, expires_at=self._clock() + self._ttl_seconds
+            )
+            if policy.groups:
+                logger.debug(
+                    "robots.txt policy loaded",
+                    host=host,
+                    port=port,
+                    agents=sorted(policy.groups),
+                )
+            return policy
+
+    def _sweep(self) -> None:
+        """Drop expired policies and locks nobody is waiting on."""
+        now = self._clock()
+        self._cache = {k: v for k, v in self._cache.items() if v.expires_at > now}
+        # A held or contended lock must survive: dropping it would let a second
+        # waiter start a duplicate fetch. An idle lock is safe to recreate.
+        self._locks = {k: v for k, v in self._locks.items() if v.locked()}

--- a/src/gopher_mcp/robots.py
+++ b/src/gopher_mcp/robots.py
@@ -58,7 +58,7 @@ ROBOTS_MAX_BYTES = 512_000
 # Advertised token for this project. The Gemini companion spec explicitly lets a
 # bot honour directives aimed at "their own individual User-agent which they
 # prominently advertise", so operators can name us specifically.
-PROJECT_TOKEN = "gopher-mcp"  # nosec B105 - a robots.txt agent name, not a secret
+PROJECT_TOKEN = "gopher-mcp"  # nosec B105 # a robots.txt agent name, not a secret
 
 # Gopher: Veronica-2's documented convention. `veronica` is deliberately NOT
 # claimed -- that token belongs to Floodgap's indexer, not to us.

--- a/src/gopher_mcp/server.py
+++ b/src/gopher_mcp/server.py
@@ -146,12 +146,16 @@ class ClientManager:
                     max_menu_items=gopher_config.max_menu_items,
                     requests_per_minute=gopher_config.requests_per_minute,
                     max_concurrent_requests=gopher_config.max_concurrent_requests,
+                    respect_robots_txt=gopher_config.respect_robots_txt,
+                    robots_cache_ttl_seconds=gopher_config.robots_cache_ttl_seconds,
+                    robots_honor_ai_tokens=gopher_config.robots_honor_ai_tokens,
                 )
                 logger.info(
                     "Gopher client initialized",
                     allowed_hosts=gopher_config.allowed_hosts,
                     cache_enabled=self._gopher_client.cache_enabled,
                     timeout_seconds=self._gopher_client.timeout_seconds,
+                    respect_robots_txt=self._gopher_client.respect_robots_txt,
                 )
             return self._gopher_client
 
@@ -192,6 +196,9 @@ class ClientManager:
                     requests_per_minute=gemini_config.requests_per_minute,
                     max_concurrent_requests=gemini_config.max_concurrent_requests,
                     denied_mime_types=gemini_config.denied_mime_types,
+                    respect_robots_txt=gemini_config.respect_robots_txt,
+                    robots_cache_ttl_seconds=gemini_config.robots_cache_ttl_seconds,
+                    robots_honor_ai_tokens=gemini_config.robots_honor_ai_tokens,
                 )
                 logger.info(
                     "Gemini client initialized",
@@ -200,6 +207,7 @@ class ClientManager:
                     timeout_seconds=self._gemini_client.timeout_seconds,
                     tofu_enabled=self._gemini_client.tofu_enabled,
                     client_certs_enabled=self._gemini_client.client_certs_enabled,
+                    respect_robots_txt=self._gemini_client.respect_robots_txt,
                 )
             return self._gemini_client
 
@@ -368,11 +376,13 @@ async def _batch_fetch(
 
 @mcp.tool(annotations=_FETCH_ANNOTATIONS, title="Fetch multiple Gopher resources")
 async def gopher_batch_fetch(urls: list[str]) -> list[dict[str, Any]]:
-    """Fetch multiple Gopher URLs in parallel for improved performance.
+    """Fetch multiple Gopher URLs concurrently.
 
-    Uses asyncio.gather() to fetch all URLs concurrently, which is much
-    faster than fetching them sequentially. Useful for fetching multiple
-    menu items or related resources at once.
+    Useful for fetching several menu items or related resources at once.
+    Concurrency is bounded, and requests to the SAME host are spaced out by
+    the per-host rate limit (one per second by default), so a batch aimed at
+    one server is paced rather than parallel. Batching several different hosts
+    is where the real speedup is.
 
     Args:
         urls: List of Gopher URLs to fetch (at most 50 per call)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,3 +37,81 @@ def test_configure_logging_writes_application_logs_to_file(tmp_path):
 
     contents = log_file.read_text(encoding="utf-8")
     assert "ssrf_block_event" in contents
+
+
+class TestPolitenessDefaults:
+    """Rate limiting ships enabled; robots checking ships opt-in."""
+
+    def test_rate_limiting_is_on_by_default(self):
+        from gopher_mcp.config import GeminiConfig, GopherConfig
+
+        assert GopherConfig().requests_per_minute == 60.0
+        assert GeminiConfig().requests_per_minute == 60.0
+
+    def test_concurrency_is_capped_by_default(self):
+        from gopher_mcp.config import GeminiConfig, GopherConfig
+
+        assert GopherConfig().max_concurrent_requests == 5
+        assert GeminiConfig().max_concurrent_requests == 5
+
+    def test_robots_is_off_by_default(self):
+        from gopher_mcp.config import GeminiConfig, GopherConfig
+
+        assert GopherConfig().respect_robots_txt is False
+        assert GeminiConfig().respect_robots_txt is False
+
+    def test_robots_defaults(self):
+        from gopher_mcp.config import GeminiConfig, GopherConfig
+
+        for cfg in (GopherConfig(), GeminiConfig()):
+            assert cfg.robots_cache_ttl_seconds == 86400
+            assert cfg.robots_honor_ai_tokens is True
+
+    def test_robots_env_vars(self, monkeypatch):
+        from gopher_mcp.config import GeminiConfig, GopherConfig
+
+        monkeypatch.setenv("GOPHER_RESPECT_ROBOTS_TXT", "true")
+        monkeypatch.setenv("GOPHER_ROBOTS_CACHE_TTL_SECONDS", "3600")
+        monkeypatch.setenv("GEMINI_RESPECT_ROBOTS_TXT", "true")
+        monkeypatch.setenv("GEMINI_ROBOTS_HONOR_AI_TOKENS", "false")
+
+        gopher = GopherConfig()
+        assert gopher.respect_robots_txt is True
+        assert gopher.robots_cache_ttl_seconds == 3600
+
+        gemini = GeminiConfig()
+        assert gemini.respect_robots_txt is True
+        assert gemini.robots_honor_ai_tokens is False
+
+    def test_defaults_match_the_client_constants(self):
+        """config.py restates these as literals (the module's convention).
+
+        This test is the guard against the two drifting apart.
+        """
+        from gopher_mcp import gemini_client, gopher_client
+        from gopher_mcp.config import GeminiConfig, GopherConfig
+
+        # Each client module carries its own copy, as it already does for
+        # response size and timeout; guard both against drifting from config.
+        for module, cfg in (
+            (gopher_client, GopherConfig()),
+            (gemini_client, GeminiConfig()),
+        ):
+            assert cfg.requests_per_minute == module.DEFAULT_REQUESTS_PER_MINUTE
+            assert cfg.max_concurrent_requests == (
+                module.DEFAULT_MAX_CONCURRENT_REQUESTS
+            )
+            assert cfg.robots_cache_ttl_seconds == (
+                module.DEFAULT_ROBOTS_CACHE_TTL_SECONDS
+            )
+
+    def test_the_two_client_modules_agree(self):
+        """gopher_client and gemini_client each carry their own copy."""
+        from gopher_mcp import gemini_client, gopher_client
+
+        for const in (
+            "DEFAULT_REQUESTS_PER_MINUTE",
+            "DEFAULT_MAX_CONCURRENT_REQUESTS",
+            "DEFAULT_ROBOTS_CACHE_TTL_SECONDS",
+        ):
+            assert getattr(gopher_client, const) == getattr(gemini_client, const)

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -198,6 +198,9 @@ class TestGeminiClientFetch:
             cache_enabled=False,
             tofu_enabled=False,
             client_certs_enabled=False,
+            # Rate limiting is on by default and would serialize same-host
+            # requests to one per second, hiding the concurrency behaviour.
+            requests_per_minute=0,
         )
         inflight = 0
         peak = 0

--- a/tests/test_gopher_client.py
+++ b/tests/test_gopher_client.py
@@ -836,8 +836,13 @@ class TestFetchContentMethod:
         assert isinstance(result, BinaryResult)
 
     @pytest.mark.asyncio
-    async def test_fetch_content_acquires_rate_limiter(self):
-        """Each network fetch passes through the per-host rate limiter."""
+    async def test_fetch_acquires_rate_limiter(self):
+        """Each network fetch passes through the per-host rate limiter.
+
+        The limiter is acquired in ``_bounded_fetch``, deliberately *outside*
+        the concurrency semaphore; see
+        ``test_rate_limiter_waits_outside_the_concurrency_cap``.
+        """
         client = GopherClient()
         client._rate_limiter.acquire = AsyncMock()  # type: ignore[method-assign]
         parsed_url = GopherURL(
@@ -847,8 +852,43 @@ class TestFetchContentMethod:
             "gopher_mcp.gopher_client.fetch_gopher",
             new=AsyncMock(return_value=b"hi"),
         ):
-            await client._fetch_content(parsed_url)
+            await client._bounded_fetch(parsed_url)
         client._rate_limiter.acquire.assert_awaited_once_with("example.com")
+
+    @pytest.mark.asyncio
+    async def test_rate_limiter_waits_outside_the_concurrency_cap(self):
+        """A throttled host must not occupy concurrency slots while sleeping.
+
+        Both settings now ship enabled, so sleeping inside the semaphore would
+        let one slow host starve unrelated hosts that are not throttled at all.
+        """
+
+        from gopher_mcp.models import TextResult
+
+        client = GopherClient(
+            cache_enabled=False, max_concurrent_requests=1, requests_per_minute=60
+        )
+        held = []
+
+        async def fake(_parsed_url):
+            held.append(client._fetch_semaphore._value)
+            return TextResult(bytes=2, text="hi")
+
+        client._fetch_content = fake  # type: ignore[method-assign]
+        sleeps = []
+
+        async def fake_sleep(seconds):
+            # The semaphore must be free while the limiter is waiting.
+            sleeps.append(client._fetch_semaphore._value)
+
+        client._rate_limiter._sleep = fake_sleep  # type: ignore[method-assign]
+        await client.fetch("gopher://example.com/0/a")
+        await client.fetch("gopher://example.com/0/b")
+
+        assert sleeps, "expected the limiter to throttle the second request"
+        # 1 == the whole cap is still available while we wait.
+        assert all(v == 1 for v in sleeps)
+        await client.close()
 
     @pytest.mark.asyncio
     async def test_fetch_internal_host_is_blocked(self):
@@ -896,7 +936,11 @@ class TestFetchContentMethod:
 
         from gopher_mcp.models import TextResult
 
-        client = GopherClient(max_concurrent_requests=2, cache_enabled=False)
+        # Rate limiting is on by default and would serialize same-host
+        # requests to one per second, hiding the concurrency behaviour.
+        client = GopherClient(
+            max_concurrent_requests=2, cache_enabled=False, requests_per_minute=0
+        )
         inflight = 0
         peak = 0
 
@@ -916,13 +960,44 @@ class TestFetchContentMethod:
         await client.close()
 
     @pytest.mark.asyncio
-    async def test_unlimited_concurrency_by_default(self):
-        """The cap is opt-in: default (0) leaves concurrency unbounded."""
+    async def test_concurrency_capped_by_default(self):
+        """The cap ships on: a default client bounds in-flight fetches."""
+        import asyncio
+
+        from gopher_mcp.gopher_client import DEFAULT_MAX_CONCURRENT_REQUESTS
+        from gopher_mcp.models import TextResult
+
+        # Rate limiting is also on by default and would serialize these to one
+        # per second, hiding what this test measures; disable just that.
+        client = GopherClient(cache_enabled=False, requests_per_minute=0)
+        inflight = 0
+        peak = 0
+
+        async def fake(_parsed_url):
+            nonlocal inflight, peak
+            inflight += 1
+            peak = max(peak, inflight)
+            await asyncio.sleep(0.02)
+            inflight -= 1
+            return TextResult(bytes=2, text="hi")
+
+        client._fetch_content = fake  # type: ignore[method-assign]
+        await asyncio.gather(
+            *[client.fetch(f"gopher://example.com/0/{i}") for i in range(10)]
+        )
+        assert peak == DEFAULT_MAX_CONCURRENT_REQUESTS
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_unlimited_concurrency_when_explicitly_disabled(self):
+        """Setting the cap to 0 still means unbounded."""
         import asyncio
 
         from gopher_mcp.models import TextResult
 
-        client = GopherClient(cache_enabled=False)  # default: no cap
+        client = GopherClient(
+            cache_enabled=False, max_concurrent_requests=0, requests_per_minute=0
+        )
         inflight = 0
         peak = 0
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -265,7 +265,9 @@ class TestScalability:
     @pytest.mark.asyncio
     async def test_connection_pool_efficiency(self):
         """Test connection pooling efficiency."""
-        client = GeminiClient()
+        # Politeness throttling is on by default and would dominate the timing
+        # here; this test is about per-request overhead, so disable it.
+        client = GeminiClient(requests_per_minute=0)
 
         # Test reusing connections to same host
         same_host_urls = [f"gemini://example.com/page{i}" for i in range(5)]
@@ -408,7 +410,8 @@ class TestLoadTesting:
     @pytest.mark.asyncio
     async def test_sustained_load(self):
         """Test sustained load over time."""
-        client = GeminiClient()
+        # Throughput test: measure the client, not the per-host rate limiter.
+        client = GeminiClient(requests_per_minute=0)
         mock_response = b"20 text/plain\r\nTest content"
 
         # Run sustained load for a period

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,0 +1,877 @@
+"""Tests for robot exclusion (robots.txt) support.
+
+Covers the parser (which deliberately implements the original 1994 grammar
+rather than RFC 9309), the caching gate, and the integration of both into the
+Gopher and Gemini clients.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+from gopher_mcp.gemini_client import GeminiClient
+from gopher_mcp.gopher_client import GopherClient
+from gopher_mcp.models import (
+    ErrorResult,
+    GeminiErrorResult,
+    GeminiSuccessResult,
+    TextResult,
+)
+from gopher_mcp.robots import (
+    AI_AGENT_TOKENS,
+    GEMINI_TOKENS,
+    GOPHER_TOKENS,
+    RobotsGate,
+    RobotsUnavailable,
+    gopher_candidate_paths,
+    parse_robots,
+)
+
+
+class _FakeClock:
+    """A controllable monotonic clock."""
+
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+
+class TestParser:
+    """The 1994 grammar: only #, User-agent: and Disallow: are recognised."""
+
+    def test_basic_group(self):
+        policy = parse_robots("User-agent: *\nDisallow: /private/\n")
+        assert policy.groups == {"*": ["/private/"]}
+
+    def test_allow_is_ignored(self):
+        """The highest-value regression test in this file.
+
+        The Gemini companion spec uses the 1994 grammar, which has no ``Allow:``
+        and says "All other lines are ignored". An RFC 9309 parser would honour
+        the Allow and permit /public/, i.e. behave MORE permissively than the
+        capsule author intended.
+        """
+        policy = parse_robots("User-agent: *\nDisallow: /\nAllow: /public/\n")
+        assert policy.groups == {"*": ["/"]}
+        assert policy.is_allowed(["/public/page"], GEMINI_TOKENS) is False
+
+    def test_other_fields_ignored(self):
+        policy = parse_robots(
+            "User-agent: *\n"
+            "Crawl-delay: 10\n"
+            "Sitemap: gemini://example.com/sitemap\n"
+            "Disallow: /x\n"
+        )
+        assert policy.groups == {"*": ["/x"]}
+
+    def test_comments_and_blank_lines(self):
+        policy = parse_robots(
+            "# leading comment\n\nUser-agent: indexer  # trailing\nDisallow: /a\n"
+        )
+        assert policy.groups == {"indexer": ["/a"]}
+
+    def test_tokens_are_lowercased(self):
+        policy = parse_robots("User-Agent: ClaudeBot\nDisallow: /\n")
+        assert "claudebot" in policy.groups
+
+    def test_consecutive_agents_share_rules(self):
+        policy = parse_robots(
+            "User-agent: indexer\nUser-agent: archiver\nDisallow: /no\n"
+        )
+        assert policy.groups == {"indexer": ["/no"], "archiver": ["/no"]}
+
+    def test_disallow_closes_the_agent_run(self):
+        """A User-agent after a Disallow starts a fresh record."""
+        policy = parse_robots(
+            "User-agent: a\nDisallow: /one\nUser-agent: b\nDisallow: /two\n"
+        )
+        assert policy.groups == {"a": ["/one"], "b": ["/two"]}
+
+    def test_empty_disallow_means_allow_everything(self):
+        policy = parse_robots("User-agent: *\nDisallow:\n")
+        assert policy.groups == {"*": []}
+        assert policy.is_allowed(["/anything"], GEMINI_TOKENS) is True
+
+    def test_disallow_without_agent_is_dropped(self):
+        assert parse_robots("Disallow: /orphan\n").groups == {}
+
+    def test_garbage_parses_to_allow_all(self):
+        """A Gopher server has no way to say "no such selector".
+
+        Whatever it returns instead -- a menu, an error document, HTML -- must
+        collapse to an empty policy rather than being misread as rules.
+        """
+        menu = (
+            "iThis is a Gopher menu\t\terror.host\t1\r\n1Some dir\t/dir\thost\t70\r\n"
+        )
+        assert parse_robots(menu).groups == {}
+        assert parse_robots("<html><body>404 Not Found</body></html>").groups == {}
+        assert parse_robots("").groups == {}
+
+
+class TestMatching:
+    def test_prefix_match(self):
+        policy = parse_robots("User-agent: *\nDisallow: /priv\n")
+        assert policy.is_allowed(["/private/x"], ("*",)) is False
+        assert policy.is_allowed(["/public/x"], ("*",)) is True
+
+    def test_wildcard_and_anchor(self):
+        policy = parse_robots("User-agent: *\nDisallow: /*.gmi$\n")
+        assert policy.is_allowed(["/a/b.gmi"], ("*",)) is False
+        assert policy.is_allowed(["/a/b.txt"], ("*",)) is True
+
+    def test_specific_token_beats_catch_all(self):
+        policy = parse_robots(
+            "User-agent: *\nDisallow: /\nUser-agent: webproxy\nDisallow:\n"
+        )
+        # The webproxy group is empty, so nothing is disallowed for us even
+        # though the catch-all forbids everything.
+        assert policy.is_allowed(["/anything"], GEMINI_TOKENS) is True
+
+    def test_union_of_matching_tokens_is_most_restrictive(self):
+        """The companion spec's own tie-breaker for overlapping categories."""
+        policy = parse_robots(
+            "User-agent: webproxy\nDisallow: /a\nUser-agent: indexer\nDisallow: /b\n"
+        )
+        assert policy.is_allowed(["/a"], GEMINI_TOKENS) is False
+        assert policy.is_allowed(["/b"], GEMINI_TOKENS) is False
+        assert policy.is_allowed(["/c"], GEMINI_TOKENS) is True
+
+    def test_unmatched_agent_is_ignored(self):
+        policy = parse_robots("User-agent: veronica\nDisallow: /\n")
+        # We never claim the `veronica` token, so its rules are not ours.
+        assert policy.is_allowed(["/x"], GOPHER_TOKENS) is True
+
+    def test_project_token_is_honoured(self):
+        policy = parse_robots("User-agent: gopher-mcp\nDisallow: /secret\n")
+        assert policy.is_allowed(["/secret/x"], GOPHER_TOKENS) is False
+
+    def test_empty_policy_allows(self):
+        assert parse_robots("").is_allowed(["/x"], GOPHER_TOKENS) is True
+
+
+class TestGopherCandidatePaths:
+    def test_both_spellings_generated(self):
+        """quux.org lists rules against the selector AND the typed URI path."""
+        paths = gopher_candidate_paths("1", "/Archives/mirrors")
+        assert "/Archives/mirrors" in paths
+        assert "/1/Archives/mirrors" in paths
+        assert "1/Archives/mirrors" in paths
+
+    def test_selector_without_leading_slash(self):
+        assert "/foo" in gopher_candidate_paths("0", "foo")
+
+    def test_rule_written_either_way_matches(self):
+        policy = parse_robots("User-agent: *\nDisallow: 1/Archives/\n")
+        paths = gopher_candidate_paths("1", "/Archives/mirrors")
+        assert policy.is_allowed(paths, ("*",)) is False
+
+
+class TestRobotsGate:
+    async def test_allows_when_no_policy(self):
+        async def fetcher(host, port):
+            return None
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=False
+        )
+        assert (await gate.allows("example.com", 70, ["/x"])).allowed is True
+
+    async def test_denies_on_disallow(self):
+        async def fetcher(host, port):
+            return "User-agent: *\nDisallow: /\n"
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=False
+        )
+        assert (await gate.allows("example.com", 70, ["/x"])).allowed is False
+
+    async def test_result_is_cached(self):
+        calls = []
+
+        async def fetcher(host, port):
+            calls.append((host, port))
+            return "User-agent: *\nDisallow: /no\n"
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=False
+        )
+        for _ in range(5):
+            await gate.allows("example.com", 70, ["/ok"])
+        assert len(calls) == 1
+
+    async def test_concurrent_lookups_fetch_once(self):
+        """A batch of 10 URLs on one host must not trigger 10 robots fetches."""
+        calls = []
+
+        async def fetcher(host, port):
+            calls.append(host)
+            await asyncio.sleep(0.01)
+            return "User-agent: *\nDisallow: /no\n"
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=False
+        )
+        await asyncio.gather(
+            *[gate.allows("example.com", 70, [f"/p{i}"]) for i in range(10)]
+        )
+        assert len(calls) == 1
+
+    async def test_cache_expires(self):
+        calls = []
+        clock = _FakeClock()
+
+        async def fetcher(host, port):
+            calls.append(1)
+            return "User-agent: *\nDisallow: /no\n"
+
+        gate = RobotsGate(
+            fetcher=fetcher,
+            tokens=("*",),
+            ttl_seconds=100,
+            fail_closed=False,
+            clock=clock,
+        )
+        await gate.allows("example.com", 70, ["/ok"])
+        clock.t += 50
+        await gate.allows("example.com", 70, ["/ok"])
+        assert len(calls) == 1
+        clock.t += 100  # past the TTL
+        await gate.allows("example.com", 70, ["/ok"])
+        assert len(calls) == 2
+
+    async def test_hosts_are_cached_separately(self):
+        async def fetcher(host, port):
+            return "User-agent: *\nDisallow: /\n" if host == "closed.example" else None
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=False
+        )
+        assert (await gate.allows("closed.example", 70, ["/x"])).allowed is False
+        assert (await gate.allows("open.example", 70, ["/x"])).allowed is True
+
+    async def test_port_is_part_of_the_cache_key(self):
+        async def fetcher(host, port):
+            return "User-agent: *\nDisallow: /\n" if port == 70 else None
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=False
+        )
+        assert (await gate.allows("example.com", 70, ["/x"])).allowed is False
+        assert (await gate.allows("example.com", 7070, ["/x"])).allowed is True
+
+    async def test_fail_open_on_unavailable(self):
+        async def fetcher(host, port):
+            raise RobotsUnavailable("boom")
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=False
+        )
+        assert (await gate.allows("example.com", 70, ["/x"])).allowed is True
+
+    async def test_fail_closed_on_unavailable(self):
+        """RFC 9309 s2.3.1.4: a temporary failure means a complete disallow."""
+
+        async def fetcher(host, port):
+            raise RobotsUnavailable("boom")
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=True
+        )
+        assert (await gate.allows("example.com", 70, ["/x"])).allowed is False
+
+    async def test_unavailable_falls_back_to_stale_policy(self):
+        """A blip must not throw away a policy we already fetched."""
+        state = {"fail": False}
+
+        async def fetcher(host, port):
+            if state["fail"]:
+                raise RobotsUnavailable("blip")
+            return "User-agent: *\nDisallow: /no\n"
+
+        clock = _FakeClock()
+        gate = RobotsGate(
+            fetcher=fetcher,
+            tokens=("*",),
+            ttl_seconds=10,
+            fail_closed=True,
+            clock=clock,
+        )
+        assert (await gate.allows("example.com", 70, ["/ok"])).allowed is True
+        clock.t += 100  # expire the entry
+        state["fail"] = True
+        # Stale rules still apply rather than blanket-denying.
+        assert (await gate.allows("example.com", 70, ["/ok"])).allowed is True
+        assert (await gate.allows("example.com", 70, ["/no"])).allowed is False
+
+    async def test_transient_failure_is_not_cached(self):
+        calls = []
+        state = {"fail": True}
+
+        async def fetcher(host, port):
+            calls.append(1)
+            if state["fail"]:
+                raise RobotsUnavailable("blip")
+            return "User-agent: *\nDisallow:\n"
+
+        gate = RobotsGate(
+            fetcher=fetcher, tokens=("*",), ttl_seconds=600, fail_closed=True
+        )
+        assert (await gate.allows("example.com", 70, ["/x"])).allowed is False
+        state["fail"] = False
+        assert (await gate.allows("example.com", 70, ["/x"])).allowed is True
+        assert len(calls) == 2
+
+
+class TestGopherClientIntegration:
+    async def test_disabled_by_default(self):
+        client = GopherClient()
+        assert client.respect_robots_txt is False
+        assert client._robots_gate is None
+        await client.close()
+
+    async def test_no_robots_fetch_when_disabled(self):
+        client = GopherClient(cache_enabled=False, requests_per_minute=0)
+        with patch.object(client, "_fetch_robots") as robots:
+            client._fetch_content = _fake_gopher_content()
+            await client.fetch("gopher://example.com/0/page")
+            robots.assert_not_called()
+        await client.close()
+
+    async def test_disallow_blocks_the_fetch(self):
+        client = GopherClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gopher_content()
+        with patch.object(
+            client, "_fetch_robots", return_value="User-agent: *\nDisallow: /\n"
+        ):
+            result = await client.fetch("gopher://example.com/0/page")
+        assert isinstance(result, ErrorResult)
+        assert result.error["code"] == "BLOCKED_BY_ROBOTS"
+        await client.close()
+
+    async def test_allowed_path_still_fetches(self):
+        client = GopherClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gopher_content()
+        with patch.object(
+            client, "_fetch_robots", return_value="User-agent: *\nDisallow: /private/\n"
+        ):
+            result = await client.fetch("gopher://example.com/0/public/page")
+        assert isinstance(result, TextResult)
+        await client.close()
+
+    async def test_gate_beats_the_content_cache(self):
+        """A Disallow must withhold content cached from an earlier run."""
+        client = GopherClient(requests_per_minute=0)
+        client._fetch_content = _fake_gopher_content()
+        url = "gopher://example.com/0/page"
+
+        # Warm the cache with robots checking off.
+        assert isinstance(await client.fetch(url), TextResult)
+
+        client.respect_robots_txt = True
+        from gopher_mcp.robots import GOPHER_TOKENS as _t
+
+        async def deny(host, port):
+            return "User-agent: *\nDisallow: /\n"
+
+        client._robots_gate = RobotsGate(
+            fetcher=deny, tokens=_t, ttl_seconds=60, fail_closed=False
+        )
+        result = await client.fetch(url)
+        assert isinstance(result, ErrorResult)
+        assert result.error["code"] == "BLOCKED_BY_ROBOTS"
+        await client.close()
+
+    async def test_robots_lookup_does_not_deadlock_at_concurrency_one(self):
+        """The lookup must not run inside the fetch semaphore.
+
+        ``_bounded_fetch`` holds ``_fetch_semaphore``; a robots fetch issued
+        from within it would self-deadlock whenever the cap is 1.
+        """
+        client = GopherClient(
+            cache_enabled=False,
+            requests_per_minute=0,
+            max_concurrent_requests=1,
+            respect_robots_txt=True,
+        )
+        client._fetch_content = _fake_gopher_content()
+        with patch.object(
+            client, "_fetch_robots", return_value="User-agent: *\nDisallow: /no\n"
+        ):
+            result = await asyncio.wait_for(
+                client.fetch("gopher://example.com/0/page"), timeout=2.0
+            )
+        assert isinstance(result, TextResult)
+        await client.close()
+
+    async def test_robots_fetch_does_not_recurse(self):
+        """The gate's fetcher must not re-enter the gated fetch path."""
+        client = GopherClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gopher_content()
+        calls = []
+
+        async def counting_fetch_gopher(*args, **kwargs):
+            calls.append(args)
+            return b"User-agent: *\nDisallow: /no\n"
+
+        with patch(
+            "gopher_mcp.gopher_client.validate_target", return_value=["93.184.216.34"]
+        ):
+            with patch(
+                "gopher_mcp.gopher_client.fetch_gopher",
+                side_effect=counting_fetch_gopher,
+            ):
+                result = await asyncio.wait_for(
+                    client.fetch("gopher://example.com/0/page"), timeout=2.0
+                )
+        assert isinstance(result, TextResult)
+        # Exactly one robots.txt request, for the root selector.
+        assert len(calls) == 1
+        assert calls[0][2] == "/robots.txt"
+        await client.close()
+
+    async def test_unreachable_host_fails_open(self):
+        """Gopher cannot distinguish "no file" from "no server"."""
+        from gopher_mcp.gopher_transport import GopherProtocolError
+
+        client = GopherClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gopher_content()
+        with patch(
+            "gopher_mcp.gopher_client.validate_target", return_value=["93.184.216.34"]
+        ):
+            with patch(
+                "gopher_mcp.gopher_client.fetch_gopher",
+                side_effect=GopherProtocolError("timed out"),
+            ):
+                result = await client.fetch("gopher://example.com/0/page")
+        assert isinstance(result, TextResult)
+        await client.close()
+
+
+class TestGeminiClientIntegration:
+    async def test_disabled_by_default(self):
+        client = GeminiClient()
+        assert client.respect_robots_txt is False
+        assert client._robots_gate is None
+        await client.close()
+
+    async def test_disallow_blocks_the_fetch(self):
+        client = GeminiClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gemini_content()
+        with patch.object(
+            client, "_fetch_robots", return_value="User-agent: *\nDisallow: /\n"
+        ):
+            result = await client.fetch("gemini://example.com/page")
+        assert isinstance(result, GeminiErrorResult)
+        assert result.error["code"] == "BLOCKED_BY_ROBOTS"
+        await client.close()
+
+    async def test_webproxy_token_is_honoured(self):
+        client = GeminiClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gemini_content()
+        with patch.object(
+            client,
+            "_fetch_robots",
+            return_value="User-agent: webproxy\nDisallow: /private/\n",
+        ):
+            blocked = await client.fetch("gemini://example.com/private/x")
+            allowed = await client.fetch("gemini://example.com/public/x")
+        assert isinstance(blocked, GeminiErrorResult)
+        assert isinstance(allowed, GeminiSuccessResult)
+        await client.close()
+
+    async def test_status_51_means_no_policy(self):
+        """Gemini inverts HTTP's numbering: 5x is permanent, and 51 NOT FOUND
+        is simply how a capsule says it has no robots.txt."""
+        client = GeminiClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gemini_content(
+            robots=GeminiErrorResult(
+                error={"code": "NOT_FOUND", "message": "not found", "status": 51}
+            )
+        )
+        result = await client.fetch("gemini://example.com/page")
+        assert isinstance(result, GeminiSuccessResult)
+        await client.close()
+
+    async def test_status_4x_fails_closed(self):
+        """A temporary failure is RFC 9309 s2.3.1.4's complete disallow."""
+        client = GeminiClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gemini_content(
+            robots=GeminiErrorResult(
+                error={"code": "UNAVAILABLE", "message": "temp", "status": 41}
+            )
+        )
+        result = await client.fetch("gemini://example.com/page")
+        assert isinstance(result, GeminiErrorResult)
+        assert result.error["code"] == "BLOCKED_BY_ROBOTS"
+        await client.close()
+
+    async def test_robots_request_is_size_capped(self):
+        from gopher_mcp.robots import ROBOTS_MAX_BYTES
+
+        client = GeminiClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        seen = {}
+
+        async def fake_fetch_content(
+            parsed_url, *, max_bytes=None, apply_content_policy=True
+        ):
+            if parsed_url.path == "/robots.txt":
+                seen["max_bytes"] = max_bytes
+                return GeminiErrorResult(
+                    error={"code": "NOT_FOUND", "message": "x", "status": 51}
+                )
+            return _gemini_success()
+
+        client._fetch_content = fake_fetch_content
+        await client.fetch("gemini://example.com/page")
+        assert seen["max_bytes"] == ROBOTS_MAX_BYTES
+        await client.close()
+
+    async def test_robots_lookup_does_not_deadlock_at_concurrency_one(self):
+        """The lookup must bypass ``_bounded_fetch``, which holds the semaphore."""
+        client = GeminiClient(
+            cache_enabled=False,
+            requests_per_minute=0,
+            max_concurrent_requests=1,
+            respect_robots_txt=True,
+        )
+        client._fetch_content = _fake_gemini_content(
+            robots=GeminiErrorResult(
+                error={"code": "NOT_FOUND", "message": "x", "status": 51}
+            )
+        )
+        result = await asyncio.wait_for(
+            client.fetch("gemini://example.com/page"), timeout=2.0
+        )
+        assert isinstance(result, GeminiSuccessResult)
+        await client.close()
+
+
+class TestBatchToolsAreGated:
+    """The batch tools route through client.fetch, so the gate covers them."""
+
+    async def test_gopher_batch_is_blocked(self):
+        from gopher_mcp import server
+
+        client = GopherClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gopher_content()
+
+        class _Manager:
+            async def get_gopher_client(self):
+                return client
+
+        with patch.object(
+            client, "_fetch_robots", return_value="User-agent: *\nDisallow: /\n"
+        ):
+            with patch.object(server, "get_client_manager", return_value=_Manager()):
+                results = await server.gopher_batch_fetch(
+                    [f"gopher://example.com/0/p{i}" for i in range(3)]
+                )
+        assert len(results) == 3
+        for item in results:
+            assert item["error"]["code"] == "BLOCKED_BY_ROBOTS"
+        await client.close()
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _fake_gopher_content():
+    async def fake(_parsed_url):
+        return TextResult(bytes=2, text="hi")
+
+    return fake
+
+
+def _gemini_success():
+    return GeminiSuccessResult(
+        mimeType={"type": "text", "subtype": "plain", "full_type": "text/plain"},
+        content="hi",
+        size=2,
+    )
+
+
+def _fake_gemini_content(robots=None):
+    async def fake(parsed_url, *, max_bytes=None, apply_content_policy=True):
+        if parsed_url.path == "/robots.txt":
+            if robots is None:
+                raise AssertionError("unexpected robots fetch")
+            return robots
+        return _gemini_success()
+
+    return fake
+
+
+class TestGateMemoryIsBounded:
+    """An open-world fetcher sees unbounded distinct hosts."""
+
+    async def test_expired_entries_are_swept(self):
+        clock = _FakeClock()
+
+        async def fetcher(host, port):
+            return "User-agent: *\nDisallow: /no\n"
+
+        gate = RobotsGate(
+            fetcher=fetcher,
+            tokens=("*",),
+            ttl_seconds=10,
+            fail_closed=False,
+            clock=clock,
+        )
+        gate._sweep_threshold = 50
+
+        for i in range(60):
+            await gate.allows(f"host{i}.example", 70, ["/ok"])
+        clock.t += 1000  # expire everything
+
+        # The next lookup past the threshold triggers the sweep.
+        for i in range(60, 120):
+            await gate.allows(f"host{i}.example", 70, ["/ok"])
+
+        assert len(gate._cache) <= 120
+        assert len(gate._locks) <= gate._sweep_threshold + 1
+
+    async def test_sweep_preserves_live_entries(self):
+        calls = []
+        clock = _FakeClock()
+
+        async def fetcher(host, port):
+            calls.append(host)
+            return "User-agent: *\nDisallow: /no\n"
+
+        gate = RobotsGate(
+            fetcher=fetcher,
+            tokens=("*",),
+            ttl_seconds=10_000,
+            fail_closed=False,
+            clock=clock,
+        )
+        gate._sweep_threshold = 5
+        await gate.allows("keep.example", 70, ["/ok"])
+        for i in range(20):
+            await gate.allows(f"other{i}.example", 70, ["/ok"])
+
+        before = len(calls)
+        # Still cached: no refetch.
+        assert (await gate.allows("keep.example", 70, ["/no"])).allowed is False
+        assert len(calls) == before
+
+
+class TestReviewRegressions:
+    """One test per defect found reviewing the original implementation."""
+
+    def test_wildcard_matching_is_not_exponential(self):
+        """A hostile Disallow must not stall the event loop.
+
+        Translating the pattern to a regex produced adjacent unbounded `.*`
+        groups: eight stars took 11s against a 61-char path, nine took 93s, and
+        the match runs synchronously on the loop.
+        """
+        import time
+
+        from gopher_mcp.robots import _matches
+
+        started = time.monotonic()
+        assert _matches("/" + "*" * 24 + "zzz", "/" + "a" * 200) is False
+        assert time.monotonic() - started < 1.0
+
+    def test_ignored_field_does_not_merge_two_records(self):
+        """Only Disallow used to close a User-agent run.
+
+        `Allow:` is ignored by the 1994 grammar, but it still terminates the
+        record. Without that, agent `b` below inherited agent `a`'s identity and
+        both got `/y`.
+        """
+        policy = parse_robots("User-agent: a\nAllow: /x\nUser-agent: b\nDisallow: /y\n")
+        assert policy.groups == {"a": [], "b": ["/y"]}
+
+    def test_ai_tokens_are_additive_only(self):
+        """Claiming an AI token must never *grant* access.
+
+        Treated as an ordinary specific token, matching `ClaudeBot` suppressed
+        the blanket `User-agent: *` group, so honouring more tokens made the
+        client less restricted than ignoring them entirely.
+        """
+        policy = parse_robots(
+            "User-agent: *\nDisallow: /\nUser-agent: ClaudeBot\nDisallow: /private\n"
+        )
+        assert policy.is_allowed(["/open"], GEMINI_TOKENS, AI_AGENT_TOKENS) is False
+        assert (
+            policy.is_allowed(["/private/x"], GEMINI_TOKENS, AI_AGENT_TOKENS) is False
+        )
+
+    def test_ai_tokens_still_restrict(self):
+        policy = parse_robots("User-agent: GPTBot\nDisallow: /no\n")
+        assert policy.is_allowed(["/no/x"], GEMINI_TOKENS, AI_AGENT_TOKENS) is False
+        assert policy.is_allowed(["/yes"], GEMINI_TOKENS, AI_AGENT_TOKENS) is True
+
+    def test_percent_encoded_path_cannot_bypass(self):
+        policy = parse_robots("User-agent: *\nDisallow: /~private/\n")
+        assert policy.is_allowed(["/%7Eprivate/x"], ("*",)) is False
+
+    def test_dot_segments_cannot_bypass(self):
+        policy = parse_robots("User-agent: *\nDisallow: /private\n")
+        assert policy.is_allowed(["/pub/../private/x"], ("*",)) is False
+
+    def test_encoded_rule_matches_decoded_path(self):
+        policy = parse_robots("User-agent: *\nDisallow: /%7Eprivate/\n")
+        assert policy.is_allowed(["/~private/x"], ("*",)) is False
+
+    def test_trailing_dot_host_shares_one_policy(self):
+        """A FQDN trailing dot must not create a second, unchecked bucket."""
+
+        async def fetcher(host, port):
+            return "User-agent: *\nDisallow: /\n"
+
+        async def run():
+            gate = RobotsGate(
+                fetcher=fetcher, tokens=("*",), ttl_seconds=60, fail_closed=False
+            )
+            assert (await gate.allows("example.com", 70, ["/x"])).allowed is False
+            assert (await gate.allows("example.com.", 70, ["/x"])).allowed is False
+
+        asyncio.run(run())
+
+    async def test_gemini_gemtext_robots_is_honoured(self):
+        """text/gemini is Gemini's DEFAULT MIME.
+
+        Reading only `content` missed GeminiGemtextResult (whose text lives in
+        `raw_content`), so a policy served as text/gemini, or with an absent or
+        malformed meta, was discarded and allow-all cached for the whole TTL.
+        """
+        from gopher_mcp.models import GeminiGemtextResult, GemtextDocument
+
+        client = GeminiClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gemini_content(
+            robots=GeminiGemtextResult(
+                rawContent="User-agent: *\nDisallow: /\n",
+                document=GemtextDocument(lines=[]),
+                size=26,
+            )
+        )
+        result = await client.fetch("gemini://example.com/secret")
+        assert isinstance(result, GeminiErrorResult)
+        assert result.error["code"] == "BLOCKED_BY_ROBOTS"
+        await client.close()
+
+    async def test_gemini_robots_bypasses_the_render_cap(self):
+        """max_rendered_chars shapes what reaches the model.
+
+        Applying it to a robots.txt truncates the policy mid-file and silently
+        drops every rule past the cap.
+        """
+        client = GeminiClient(
+            cache_enabled=False,
+            requests_per_minute=0,
+            respect_robots_txt=True,
+            max_rendered_chars=10,
+        )
+        seen = {}
+
+        async def fake(parsed_url, *, max_bytes=None, apply_content_policy=True):
+            if parsed_url.path == "/robots.txt":
+                seen["policy_applied"] = apply_content_policy
+                return GeminiErrorResult(
+                    error={"code": "NOT_FOUND", "message": "x", "status": 51}
+                )
+            return _gemini_success()
+
+        client._fetch_content = fake
+        await client.fetch("gemini://example.com/page")
+        assert seen["policy_applied"] is False
+        await client.close()
+
+    async def test_gemini_robots_capped_by_max_response_size(self):
+        """A lowered max_response_size must still bound the robots read."""
+        client = GeminiClient(
+            cache_enabled=False,
+            requests_per_minute=0,
+            respect_robots_txt=True,
+            max_response_size=4096,
+        )
+        seen = {}
+
+        async def fake(parsed_url, *, max_bytes=None, apply_content_policy=True):
+            if parsed_url.path == "/robots.txt":
+                seen["max_bytes"] = max_bytes
+                return GeminiErrorResult(
+                    error={"code": "NOT_FOUND", "message": "x", "status": 51}
+                )
+            return _gemini_success()
+
+        client._fetch_content = fake
+        await client.fetch("gemini://example.com/page")
+        assert seen["max_bytes"] == 4096
+        await client.close()
+
+    async def test_gopher_transient_failure_is_not_cached(self):
+        """Returning None for a timeout cached "no policy" for 24 hours.
+
+        A blip must not disable robots checking for the host for the full TTL.
+        """
+        from gopher_mcp.gopher_transport import GopherProtocolError
+
+        client = GopherClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gopher_content()
+        state = {"fail": True}
+
+        async def flaky(*args, **kwargs):
+            if state["fail"]:
+                raise GopherProtocolError("timed out")
+            return b"User-agent: *\nDisallow: /\n"
+
+        with patch(
+            "gopher_mcp.gopher_client.validate_target", return_value=["93.184.216.34"]
+        ):
+            with patch("gopher_mcp.gopher_client.fetch_gopher", side_effect=flaky):
+                # Fails open while unreachable...
+                assert isinstance(
+                    await client.fetch("gopher://example.com/0/page"), TextResult
+                )
+                state["fail"] = False
+                # ...and the real policy applies as soon as it is reachable,
+                # rather than the failure being remembered for the whole TTL.
+                blocked = await client.fetch("gopher://example.com/0/page")
+        assert isinstance(blocked, ErrorResult)
+        assert blocked.error["code"] == "BLOCKED_BY_ROBOTS"
+        await client.close()
+
+    async def test_unavailable_reason_is_reported_distinctly(self):
+        """ "We could not find out" must not be reported as "they said no"."""
+        client = GeminiClient(
+            cache_enabled=False, requests_per_minute=0, respect_robots_txt=True
+        )
+        client._fetch_content = _fake_gemini_content(
+            robots=GeminiErrorResult(
+                error={"code": "UNAVAILABLE", "message": "temp", "status": 41}
+            )
+        )
+        result = await client.fetch("gemini://example.com/page")
+        assert isinstance(result, GeminiErrorResult)
+        assert "Could not retrieve robots.txt" in result.error["message"]
+        await client.close()


### PR DESCRIPTION
Addresses #89.

Gopherspace and Geminispace are served largely by individuals on small machines, and this server had no way for them to say no. It ignored `robots.txt` entirely, and both politeness controls shipped disabled, so a model looping over the fetch tools was unthrottled out of the box.

## Rate limiting is now on by default

`requests_per_minute` goes from `0` (off) to `60`, and `max_concurrent_requests` from `0` (unlimited) to `5`.

**This changes behaviour for existing deployments.** Set either to `0` to restore the old defaults. This is the smaller change of the two but arguably the more useful one, and it applies whether or not anyone opts into robots checking.

## robots.txt support (opt-in)

Enabled with `GOPHER_RESPECT_ROBOTS_TXT` / `GEMINI_RESPECT_ROBOTS_TXT`, off by default because it costs a round-trip per host and a blanket `Disallow: /` would otherwise silently break an existing deployment.

RFC 9309 is deliberately not the normative reference for either protocol:

- **Gemini** follows the [companion specification](https://geminiprotocol.net/docs/companion/robots.gmi), which uses the original 1994 grammar. Only `#`, `User-agent:` and `Disallow:` are recognised, and everything else is ignored. An RFC 9309 parser would act on `Allow:` lines that capsule authors expect to be dropped, making it *more* permissive than intended, which is why this carries a local parser rather than using `protego`, `reppy` or `urllib.robotparser`. Matches `gopher-mcp`, `webproxy`, `indexer` and `*`.
- **Gopher** follows the convention Veronica-2 documents, and **fails open**. With no status codes, a missing selector, an error document and an empty file are indistinguishable on the wire, and RFC 9309 section 2.3.1.4's "treat unreachable as complete disallow" would deny most of Gopherspace. The lenient parser makes this safe: content yielding no `User-agent:` group imposes no rules. Matches `gopher-mcp` and `*`, and deliberately does not claim `veronica`.

Gemini, which does have status codes, fails closed on a temporary 4x failure and treats `51 NOT FOUND` as "no policy" (5x is Gemini's *permanent* class, inverted relative to HTTP).

Rules naming AI crawler agents (`ClaudeBot`, `GPTBot`, `CCBot`, ...) are also honoured by default. They are not part of either protocol's convention, but the intent behind writing one is unambiguous.

### Design notes

- The gate runs in `fetch()` **before** the cache read, so a `Disallow` also withholds content cached from an earlier permitted run, and it covers the batch tools since they route through the same method.
- The robots lookup bypasses `_bounded_fetch`, which holds the concurrency semaphore and would self-deadlock at `max_concurrent_requests=1`.
- Rate limiting also moved outside that semaphore. Sleeping while holding a slot was harmless when the limiter was off, but now lets one throttled host starve unrelated ones.
- There is no per-directory or per-user `robots.txt`. RFC 9309 section 2.3 defines none, and neither does either protocol convention; the established pattern on shared hosts is a root file using path prefixes.

## Review fixes folded in

A review of the first pass caught several real defects, each with a named regression test in `tests/test_robots.py`:

- Gemini policies served as `text/gemini` were silently discarded (that is Gemini's *default* MIME, so a blank or malformed meta dropped the whole policy and cached allow-all for 24h)
- ReDoS in the wildcard matcher: a remote `Disallow: /********zzz` took 11s at 8 stars and blocked the event loop. Replaced with a linear scan
- `Allow:` did not close a `User-agent` group, merging two unrelated records
- AI tokens could *grant* access by suppressing a blanket `User-agent: *`. They are now additive only
- Percent-encoded and dot-segment paths could bypass rules
- Transient failures were cached as "no policy" for the full TTL
- `max_rendered_chars` truncated policies mid-file, and the MIME deny list discarded them

## Unrelated fix

Also repairs the `mypy` pre-commit hook, which was missing `pydantic-settings` (making every config class read as `cannot subclass BaseSettings`) and floated `mcp` to a different API shape than the code targets. It failed identically on a clean checkout before this branch. Happy to split it out if preferred.

## Verification

787 tests passing, coverage 94%. `ruff check`, `ruff format --check`, `uv run mypy src` and `bandit` all clean.

No release is triggered by this: `release.yml` fires only on `v*` tags and `publish.yml` is manual dispatch only.
